### PR TITLE
Update docs and README for M2 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ See [docs/getting-started.md](docs/getting-started.md) for the full setup guide.
 |---------|-------------|
 | `herd init` | Set up a repo for HerdOS (config, labels, workflows) |
 | `herd config list\|get\|set\|edit` | View and manage configuration |
-
-More commands (`plan`, `dispatch`, `status`, `batch`) are coming soon.
+| `herd plan [description]` | Plan and decompose work into issues |
+| `herd dispatch [issue\|--batch\|--all]` | Dispatch workers to execute issues |
+| `herd status [--batch\|--watch\|--json]` | Show system status |
+| `herd batch list\|show\|cancel` | Manage batches |
+| `herd runner list` | List self-hosted runners |
 
 ## Documentation
 
@@ -71,7 +74,7 @@ Anyone who's tried to coordinate multiple AI agents knows the feeling — it's l
 
 ## Status
 
-In active development. Foundation is complete — core orchestration commands are next.
+In active development. Planning, dispatch, and monitoring commands are functional. Worker execution and the Integrator are next.
 
 ## License
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,10 +65,78 @@ Customize how each HerdOS role behaves in your project by editing files in `.her
 
 These files are created empty by `herd init`. Add your project-specific instructions and commit them — they're shared across your team.
 
+## Planning Work
+
+Decompose a feature into tasks with an interactive agent session:
+
+```bash
+herd plan "Add user authentication"
+```
+
+The agent asks clarifying questions, then produces a decomposition with tasks, dependencies, and tier assignments. You can confirm, reject, or edit the plan in `$EDITOR`.
+
+To plan without auto-dispatching Tier 0:
+
+```bash
+herd plan --no-dispatch "Add user authentication"
+```
+
+Preview what would be created:
+
+```bash
+herd plan --dry-run "Add user authentication"
+```
+
+## Dispatching Workers
+
+After planning, Tier 0 tasks are dispatched automatically. To manually dispatch:
+
+```bash
+# Dispatch a single issue
+herd dispatch 42
+
+# Dispatch all ready issues in a batch
+herd dispatch --batch 5
+
+# Dispatch across all batches
+herd dispatch --all
+
+# Override concurrency limit
+herd dispatch --batch 5 --ignore-limit
+```
+
+## Monitoring Progress
+
+```bash
+# Overview of all batches and active workers
+herd status
+
+# Detailed view of a specific batch
+herd status --batch 5
+
+# Auto-refreshing dashboard
+herd status --watch
+
+# Machine-readable output
+herd status --json
+
+# Runner status
+herd status --runners
+```
+
+## Managing Batches
+
+```bash
+# List active batches
+herd batch list
+
+# Show detailed issue status for a batch
+herd batch show 5
+
+# Cancel a batch (stops workers, labels issues as failed, closes milestone)
+herd batch cancel 5
+```
+
 ## Next Steps
 
-Once initialized, you're ready to plan and dispatch work. These features are coming in the next milestone:
-
-- `herd plan` — decompose a feature into tasks
-- `herd dispatch` — send tasks to workers
-- `herd status` — monitor progress
+Worker execution and the Integrator (merge consolidation, agent review) are coming in the next milestone.


### PR DESCRIPTION
## Summary

- Update getting-started.md with usage for `herd plan`, `herd dispatch`, `herd status`, `herd batch`, `herd runner`
- Update README commands table with all M2 commands
- Update status section to reflect current state

## Test plan

- [x] Documentation only — no code changes