### PR TITLE
Add headless permission flags for automated CI execution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ agent:
   provider: "claude"             # claude (codex, cursor, gemini, opencode coming soon)
   binary: ""                     # path to agent binary (auto-detect if empty)
   model: ""                      # model override (optional, agent-specific)
+  max_turns: 0                   # max agentic turns in headless mode (0 = agent default)
 
 workers:
   max_concurrent: 3              # max simultaneous worker Actions

--- a/docs/specs/01-concepts/02-workers.md
+++ b/docs/specs/01-concepts/02-workers.md
@@ -34,6 +34,22 @@ workflow_dispatch ──▶   1. Checkout batch branch
 
 The core of a worker is `herd worker exec <issue>`, which invokes the configured agent in headless mode with a carefully constructed prompt.
 
+### Headless Permissions
+
+Workers run in fully automated CI environments with no human present. The agent must never pause for permission prompts. For Claude Code, `herd` passes `--dangerously-skip-permissions` to bypass all permission checks. This is safe because:
+
+- Workers run on **isolated self-hosted runners** (or ephemeral containers)
+- They operate on **disposable worker branches** — damage is contained
+- The Integrator reviews all changes before they reach `main`
+
+An optional `max_turns` setting in the `agent:` config section limits how many agentic turns the agent can take, preventing infinite loops in headless mode. When set to 0 (default), the agent uses its own default limit.
+
+```yaml
+agent:
+  provider: "claude"
+  max_turns: 200  # optional, 0 = agent default
+```
+
 ### Role Instructions
 
 If `.herd/worker.md` exists in the repository, its contents are appended to the worker's system prompt. This is convention-based — no configuration is needed. Drop the file in `.herd/` and it gets picked up automatically. Use this to provide project-specific worker guidance: coding standards, forbidden patterns, testing requirements, or other constraints that every worker should follow.
@@ -71,8 +87,14 @@ sections as written by the Planner>
 - Commit your changes with clear messages referencing issue #<number>.
 - Do not add features, refactor code, or make improvements beyond
   what is specified in the issue.
-- If you cannot complete the task, exit with a non-zero status and
-  include the reason in your output.
+- You are running in a fully automated CI environment with no human
+  present. Do not pause, ask questions, or wait for confirmation.
+  Figure it out. If something is broken, try to fix it. If a tool
+  fails, try a different approach. Only exit with a non-zero status
+  if the task is genuinely impossible (e.g., the issue references
+  code that doesn't exist and can't be inferred).
+- If you cannot complete the task after exhausting alternatives,
+  exit with a non-zero status and include the reason in your output.
 ```
 
 The full issue body is passed through verbatim — it is not summarized, reformatted, or truncated. The Implementation Details, Conventions, and Context from Dependencies sections are written by the Planner specifically for the worker.

--- a/docs/specs/03-cli/02-configuration.md
+++ b/docs/specs/03-cli/02-configuration.md
@@ -19,6 +19,7 @@ agent:
   provider: "claude"             # claude (codex, cursor, gemini, opencode coming soon)
   binary: ""                     # path to binary (default: auto-detect)
   model: ""                      # model override (optional, agent-specific)
+  max_turns: 0                   # max agentic turns for headless mode (0 = agent default)
 
 # Worker settings
 workers:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -34,6 +34,7 @@ type TaskSpec struct {
 type ExecOptions struct {
 	RepoRoot     string
 	SystemPrompt string
+	MaxTurns     int // Max agentic turns (0 = agent default)
 }
 
 type Plan struct {

--- a/internal/agent/claude/execute.go
+++ b/internal/agent/claude/execute.go
@@ -13,12 +13,15 @@ import (
 // The task body is passed as the prompt (-p), and the system prompt provides
 // worker instructions. The agent commits as it works in the repo.
 func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts agent.ExecOptions) (*agent.ExecResult, error) {
-	args := []string{"-p", task.Body}
+	args := []string{"-p", task.Body, "--dangerously-skip-permissions"}
 	if opts.SystemPrompt != "" {
 		args = append(args, "--system-prompt", opts.SystemPrompt)
 	}
 	if c.Model != "" {
 		args = append(args, "--model", c.Model)
+	}
+	if opts.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
 	}
 
 	cmd := exec.CommandContext(ctx, c.BinaryPath, args...)

--- a/internal/agent/claude/execute_test.go
+++ b/internal/agent/claude/execute_test.go
@@ -56,6 +56,26 @@ func TestExecute_CommandArgs(t *testing.T) {
 	}
 }
 
+func TestExecute_MaxTurns(t *testing.T) {
+	// Use a script that prints all args so we can verify --max-turns is passed
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$@\""), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	task := agent.TaskSpec{Body: "do work"}
+	opts := agent.ExecOptions{
+		RepoRoot: dir,
+		MaxTurns: 200,
+	}
+
+	result, err := a.Execute(context.Background(), task, opts)
+	require.NoError(t, err)
+	assert.Contains(t, result.Summary, "--max-turns 200")
+	assert.Contains(t, result.Summary, "--dangerously-skip-permissions")
+}
+
 func TestExecute_FailingCommand(t *testing.T) {
 	a := New("false", "") // "false" always exits with code 1
 	task := agent.TaskSpec{Body: "test"}

--- a/internal/agent/claude/review.go
+++ b/internal/agent/claude/review.go
@@ -50,7 +50,7 @@ func (c *ClaudeAgent) Review(ctx context.Context, diff string, opts agent.Review
 		return nil, fmt.Errorf("rendering review prompt: %w", err)
 	}
 
-	args := []string{"-p", prompt, "--system-prompt", reviewSystemPrompt}
+	args := []string{"-p", prompt, "--dangerously-skip-permissions", "--system-prompt", reviewSystemPrompt}
 	if c.Model != "" {
 		args = append(args, "--model", c.Model)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Agent struct {
 	Provider string `yaml:"provider"`
 	Binary   string `yaml:"binary"`
 	Model    string `yaml:"model"`
+	MaxTurns int    `yaml:"max_turns"` // Max agentic turns for headless mode (0 = agent default)
 }
 
 type Workers struct {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -52,8 +52,14 @@ const workerPromptTemplate = `You are a HerdOS worker executing a task.
 - Commit your changes with clear messages referencing issue #{{.IssueNumber}}.
 - Do not add features, refactor code, or make improvements beyond
   what is specified in the issue.
-- If you cannot complete the task, exit with a non-zero status and
-  include the reason in your output.
+- You are running in a fully automated CI environment with no human
+  present. Do not pause, ask questions, or wait for confirmation.
+  Figure it out. If something is broken, try to fix it. If a tool
+  fails, try a different approach. Only exit with a non-zero status
+  if the task is genuinely impossible (e.g., the issue references
+  code that doesn't exist and can't be inferred).
+- If you cannot complete the task after exhausting alternatives,
+  exit with a non-zero status and include the reason in your output.
 {{if .RoleInstructions}}
 ## Project-Specific Instructions
 {{.RoleInstructions}}
@@ -122,6 +128,7 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 	execOpts := agent.ExecOptions{
 		RepoRoot:     params.RepoRoot,
 		SystemPrompt: systemPrompt,
+		MaxTurns:     cfg.Agent.MaxTurns,
 	}
 
 	if _, err = ag.Execute(ctx, taskSpec, execOpts); err != nil {


### PR DESCRIPTION
## Summary

- Pass `--dangerously-skip-permissions` to Claude Code in Execute and Review invocations so workers and reviewers don't hang waiting for permission prompts in CI
- Add `agent.max_turns` config option to prevent infinite loops in headless mode
- Update worker system prompt to instruct the agent to push through problems autonomously rather than pausing for input

## Test plan

- [x] `TestExecute_MaxTurns` verifies `--max-turns` and `--dangerously-skip-permissions` flags are passed to the agent binary
- [x] All existing tests pass (`go test ./...`)