### PR TITLE
Fix Homebrew install instructions and add checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Workers execute in parallel where possible, tier by tier. If a worker fails, the
 
 ```bash
 # Install via Homebrew
-brew tap herd-os/tap && brew install herd
+brew install herd-os/tap/herd
 
 # Or download the binary (Linux amd64)
 curl -L https://github.com/Herd-OS/herd/releases/latest/download/herd-linux-amd64 -o herd

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,8 +3,7 @@
 ## Homebrew (macOS and Linux)
 
 ```bash
-brew tap herd-os/tap
-brew install herd
+brew install herd-os/tap/herd
 ```
 
 ## Binary Download
@@ -23,6 +22,14 @@ curl -L https://github.com/Herd-OS/herd/releases/latest/download/herd-darwin-arm
 
 # macOS (Intel)
 curl -L https://github.com/Herd-OS/herd/releases/latest/download/herd-darwin-amd64 -o herd
+```
+
+Verify the checksum (optional but recommended):
+
+```bash
+curl -L https://github.com/Herd-OS/herd/releases/latest/download/checksums.txt -o checksums.txt
+sha256sum herd
+# Compare the output against the matching line in checksums.txt
 ```
 
 Then install:

--- a/docs/specs/04-implementation/01-roadmap.md
+++ b/docs/specs/04-implementation/01-roadmap.md
@@ -41,7 +41,7 @@ A complete, self-healing orchestration system for a single repository.
 ### Distribution
 
 - Binary releases for Linux, macOS, Windows
-- Homebrew formula (`brew tap herd-os/tap && brew install herd`)
+- Homebrew formula (`brew install herd-os/tap/herd`)
 - User-facing documentation:
   - `README.md` — project overview, installation, quickstart (plan → dispatch → merge in 5 minutes)
   - `docs/quickstart.md` — step-by-step guide: install herd, init a repo, plan a feature, dispatch, review PR

--- a/docs/specs/04-implementation/02-project-structure.md
+++ b/docs/specs/04-implementation/02-project-structure.md
@@ -257,8 +257,7 @@ end
 Installation:
 
 ```bash
-brew tap herd-os/tap
-brew install herd
+brew install herd-os/tap/herd
 ```
 
 The formula is updated automatically by the release workflow — after uploading binaries, it computes SHA256 checksums and pushes an updated formula to the tap repo.


### PR DESCRIPTION
## Summary

- Use `brew install herd-os/tap/herd` instead of `brew install herd` to avoid collision with Laravel Herd cask
- Add checksum verification instructions to `docs/installation.md`

## Test plan

- [x] `brew install herd-os/tap/herd` works correctly