### PR TITLE
Bootstrap herd init on the herd repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# HerdOS runner environment
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+
+# GitHub Personal Access Token (required)
+# Needs 'repo' scope for private repos, or fine-grained with Actions read/write
+GITHUB_TOKEN=
+
+# Claude Code authentication (choose one):
+
+# Option 1: OAuth token (uses your Pro/Max subscription, no per-token cost)
+# Generate with: claude setup-token
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Option 2: API key (pay-per-token via console.anthropic.com)
+# ANTHROPIC_API_KEY=

--- a/.github/workflows/herd-integrator.yml
+++ b/.github/workflows/herd-integrator.yml
@@ -7,12 +7,16 @@ on:
     types: [submitted]
   pull_request:
     types: [closed]
+  issues:
+    types: [closed]
 
 permissions:
   contents: write
   issues: write
   pull-requests: write
   actions: write
+  statuses: read
+  checks: read
 
 jobs:
   integrate:
@@ -27,7 +31,7 @@ jobs:
       - name: Consolidate, advance, and review
         env:
           HERD_RUNNER: "true"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -37,6 +41,28 @@ jobs:
           herd integrator check-ci --run-id ${{ github.event.workflow_run.id }}
           herd integrator advance --run-id ${{ github.event.workflow_run.id }}
           herd integrator review --run-id ${{ github.event.workflow_run.id }}
+
+  advance-on-close:
+    if: github.event_name == 'issues'
+    runs-on: [self-hosted, '${{ vars.HERD_RUNNER_LABEL || ''herd-worker'' }}']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if herd issue and advance
+        env:
+          HERD_RUNNER: "true"
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          BODY="${{ github.event.issue.body }}"
+          BATCH=$(echo "$BODY" | grep -oP '^\s*batch:\s*\K[0-9]+' | head -1)
+          if [ -n "$BATCH" ]; then
+            herd integrator advance --batch "$BATCH"
+          else
+            echo "Not a herd issue — skipping."
+          fi
 
   re-review:
     if: >
@@ -53,7 +79,7 @@ jobs:
       - name: Handle review
         env:
           HERD_RUNNER: "true"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -79,6 +105,6 @@ jobs:
       - name: Post-merge cleanup
         env:
           HERD_RUNNER: "true"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           herd integrator cleanup --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/herd-monitor.yml
+++ b/.github/workflows/herd-monitor.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
   actions: write
 
 jobs:
@@ -19,6 +20,6 @@ jobs:
       - name: Patrol
         env:
           HERD_RUNNER: "true"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           herd monitor patrol

--- a/.github/workflows/herd-worker.yml
+++ b/.github/workflows/herd-worker.yml
@@ -1,4 +1,5 @@
 name: HerdOS Worker
+run-name: "Herd Worker #${{ inputs.issue_number }}"
 on:
   workflow_dispatch:
     inputs:
@@ -30,7 +31,7 @@ permissions:
 jobs:
   execute:
     runs-on: [self-hosted, '${{ inputs.runner_label }}']
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +42,7 @@ jobs:
       - name: Execute task
         env:
           HERD_RUNNER: "true"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 .herd/state/
+.env

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -1,0 +1,39 @@
+FROM ubuntu:24.04
+
+ARG RUNNER_VERSION=2.332.0
+ARG TARGETARCH
+
+# Dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl jq ca-certificates git gh nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub Actions runner
+RUN ARCH=$(echo "$TARGETARCH" | sed 's/amd64/x64/' | sed 's/arm64/arm64/') \
+    && mkdir /runner && cd /runner \
+    && curl -sL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz" \
+    | tar xz
+
+# Herd CLI (will switch to binary download when releases are available)
+RUN apt-get update && apt-get install -y golang-go \
+    && go install github.com/herd-os/herd/cmd/herd@latest \
+    && cp $(go env GOPATH)/bin/herd /usr/local/bin/herd \
+    && apt-get purge -y golang-go && apt-get autoremove -y
+
+# Agent CLI
+RUN npm install -g @anthropic-ai/claude-code
+
+# Project toolchain (uncomment what you need)
+# RUN apt-get update && apt-get install -y golang-go
+# RUN apt-get update && apt-get install -y python3 python3-pip
+
+# Runner must not run as root
+RUN useradd -m -d /home/runner runner \
+    && chown -R runner:runner /runner
+
+WORKDIR /runner
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+USER runner
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.herd.yml
+++ b/docker-compose.herd.yml
@@ -1,0 +1,19 @@
+# HerdOS runner configuration
+# 1. Copy .env.example to .env and fill in your tokens
+# 2. Start runners: docker compose -f docker-compose.herd.yml up -d
+# 3. Scale:         docker compose -f docker-compose.herd.yml up -d --scale worker=5
+# 4. Stop:          docker compose -f docker-compose.herd.yml down
+
+services:
+  worker:
+    build:
+      dockerfile: Dockerfile.runner
+    restart: always
+    environment:
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - REPO_URL=https://github.com/Herd-OS/herd
+      - RUNNER_LABELS=herd-worker
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+    deploy:
+      replicas: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+cleanup() {
+  echo "Removing runner..."
+  ./config.sh remove --token "$(get_token)"
+  exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+get_token() {
+  curl -s -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/runners/registration-token" \
+    | jq -r .token
+}
+
+REPO_OWNER=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\1|')
+REPO_NAME=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\2|')
+
+# Remove stale config from previous run (ephemeral runners leave config behind on restart)
+if [ -f .runner ]; then
+  ./config.sh remove --token "$(get_token)" || true
+fi
+
+./config.sh \
+  --url "$REPO_URL" \
+  --token "$(get_token)" \
+  --name "${RUNNER_NAME:-$(hostname)}" \
+  --labels "${RUNNER_LABELS:-herd-worker}" \
+  --ephemeral \
+  --unattended
+
+exec ./run.sh


### PR DESCRIPTION
## Summary
- Run `herd init` on the herd repo itself
- Adds runner infrastructure (Dockerfile, docker-compose, entrypoint, .env.example)
- Updates workflows with fixes found during development: HERD_GITHUB_TOKEN fallback, advance-on-close trigger, `fromJSON` for timeout, run-name, additional permissions

## Test plan
- [ ] Verify workflows are valid YAML
- [ ] Verify docker-compose and Dockerfile work for runner setup