### PR TITLE
Auto-update herd binary on runner container startup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,20 @@ herd init
 
 `herd init` creates a `herd/init` branch, commits the updated files, pushes, and opens a PR. Review and merge the PR to apply the changes. Configuration (`.herdos.yml`) and role instructions (`.herd/*.md`) are never overwritten.
 
+### Update runner containers
+
+Runner containers automatically download the latest herd binary on startup. Just restart them:
+
+```bash
+docker compose -f docker-compose.herd.yml restart
+```
+
+To pin a specific version, set `HERD_VERSION` in `.env`:
+
+```bash
+HERD_VERSION=v0.1.0-rc.2
+```
+
 ## Verify Installation
 
 ```bash

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -203,7 +203,7 @@ func TestCreateRunnerFiles(t *testing.T) {
 	df, err := os.ReadFile(filepath.Join(dir, "Dockerfile.runner"))
 	require.NoError(t, err)
 	assert.Contains(t, string(df), "FROM ubuntu:24.04")
-	assert.Contains(t, string(df), "go install github.com/herd-os/herd/cmd/herd@latest")
+	assert.Contains(t, string(df), "/opt/herd/bin")
 	assert.Contains(t, string(df), "ENTRYPOINT")
 
 	// entrypoint.sh
@@ -213,6 +213,8 @@ func TestCreateRunnerFiles(t *testing.T) {
 	assert.Contains(t, string(ep), "--ephemeral")
 	assert.Contains(t, string(ep), "trap cleanup SIGTERM SIGINT")
 	assert.Contains(t, string(ep), "exec ./run.sh")
+	assert.Contains(t, string(ep), "Herd-OS/herd/releases")
+	assert.Contains(t, string(ep), "HERD_VERSION")
 	info, err := os.Stat(filepath.Join(dir, "entrypoint.sh"))
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0755), info.Mode().Perm(), "entrypoint.sh should be executable")

--- a/internal/cli/runner/.env.example
+++ b/internal/cli/runner/.env.example
@@ -14,3 +14,7 @@ CLAUDE_CODE_OAUTH_TOKEN=
 
 # Option 2: API key (pay-per-token via console.anthropic.com)
 # ANTHROPIC_API_KEY=
+
+# Herd version for runner containers (optional — defaults to latest)
+# Set this to pin a specific version, e.g.:
+# HERD_VERSION=v0.1.0-rc.2

--- a/internal/cli/runner/Dockerfile.runner
+++ b/internal/cli/runner/Dockerfile.runner
@@ -14,11 +14,10 @@ RUN ARCH=$(echo "$TARGETARCH" | sed 's/amd64/x64/' | sed 's/arm64/arm64/') \
     && curl -sL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz" \
     | tar xz
 
-# Herd CLI (will switch to binary download when releases are available)
-RUN apt-get update && apt-get install -y golang-go \
-    && go install github.com/herd-os/herd/cmd/herd@latest \
-    && cp $(go env GOPATH)/bin/herd /usr/local/bin/herd \
-    && apt-get purge -y golang-go && apt-get autoremove -y
+# Herd CLI is installed at startup by entrypoint.sh
+# Set HERD_VERSION in .env to pin a version, otherwise latest is used.
+RUN mkdir -p /opt/herd/bin
+ENV PATH="/opt/herd/bin:${PATH}"
 
 # Agent CLI
 RUN npm install -g @anthropic-ai/claude-code
@@ -29,7 +28,7 @@ RUN npm install -g @anthropic-ai/claude-code
 
 # Runner must not run as root
 RUN useradd -m -d /home/runner runner \
-    && chown -R runner:runner /runner
+    && chown -R runner:runner /runner /opt/herd
 
 WORKDIR /runner
 COPY entrypoint.sh .

--- a/internal/cli/runner/docker-compose.herd.yml.tmpl
+++ b/internal/cli/runner/docker-compose.herd.yml.tmpl
@@ -15,5 +15,6 @@ services:
       - RUNNER_LABELS=herd-worker
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - HERD_VERSION=${HERD_VERSION:-}
     deploy:
       replicas: 3

--- a/internal/cli/runner/entrypoint.sh
+++ b/internal/cli/runner/entrypoint.sh
@@ -15,6 +15,18 @@ get_token() {
     | jq -r .token
 }
 
+# Install or update herd CLI
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+if [ -n "${HERD_VERSION:-}" ] && [ "$HERD_VERSION" != "latest" ]; then
+  HERD_URL="https://github.com/Herd-OS/herd/releases/download/${HERD_VERSION}/herd-linux-${ARCH}"
+else
+  HERD_URL="https://github.com/Herd-OS/herd/releases/latest/download/herd-linux-${ARCH}"
+fi
+echo "Installing herd from ${HERD_URL}..."
+curl -fsSL "$HERD_URL" -o /opt/herd/bin/herd
+chmod +x /opt/herd/bin/herd
+echo "Installed herd $(herd --version 2>/dev/null || echo 'unknown')"
+
 REPO_OWNER=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\1|')
 REPO_NAME=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\2|')
 


### PR DESCRIPTION
## Summary
- Move herd binary install from Dockerfile to entrypoint.sh — downloads latest (or pinned) version on every container start
- No rebuild needed to update herd — just `docker compose restart`
- `HERD_VERSION` env var in `.env` to pin a specific version
- Updated installation docs with simpler update instructions

## Problem
`go install @latest` was cached by Docker layers. Rebuilding containers after a herd release still used the old binary, causing the YAML frontmatter fix to not take effect.

## Test plan
- [ ] All tests pass
- [ ] Dockerfile no longer installs herd
- [ ] Entrypoint downloads herd before starting the runner