### PR TITLE
Fix git push credentials in worker and integrator workflows

### DIFF
--- a/internal/cli/workflows/herd-integrator.yml
+++ b/internal/cli/workflows/herd-integrator.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Consolidate, advance, and review
         env:
@@ -50,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Check if herd issue and advance
         env:
@@ -76,6 +78,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Handle review
         env:
@@ -103,6 +106,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Post-merge cleanup
         env:

--- a/internal/cli/workflows/herd-worker.yml
+++ b/internal/cli/workflows/herd-worker.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           ref: ${{ inputs.batch_branch || github.event.repository.default_branch }}
           fetch-depth: 0
+          token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Execute task
         env:


### PR DESCRIPTION
## Summary
- Pass `HERD_GITHUB_TOKEN` to `actions/checkout` token parameter in all workflow jobs
- The checkout action configures git credentials for subsequent pushes — without this, pushes use the default `GITHUB_TOKEN` which can't push workflow files

## Problem
Worker pushing a `.github/workflows/deploy.yml` file failed with: `refusing to allow a GitHub App to create or update workflow without workflows permission`

## Test plan
- [x] All tests pass
- [ ] Worker can push workflow files after redispatch