### PR TITLE
Unblock manual tasks on tier advancement

### DIFF
--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -269,11 +269,6 @@ func Advance(ctx context.Context, p platform.Platform, g *git.Git, cfg *config.C
 			continue
 		}
 
-		// Skip manual tasks — they are never dispatched to workers
-		if issues.HasLabel(issue.Labels, issues.TypeManual) {
-			continue
-		}
-
 		status := issues.StatusLabel(issue.Labels)
 		// Double-dispatch prevention: only dispatch blocked issues
 		if status != issues.StatusBlocked {
@@ -282,6 +277,12 @@ func Advance(ctx context.Context, p platform.Platform, g *git.Git, cfg *config.C
 
 		// Unblock: blocked → ready
 		_ = p.Issues().RemoveLabels(ctx, num, []string{issues.StatusBlocked})
+
+		// Manual tasks get unblocked but not dispatched
+		if issues.HasLabel(issue.Labels, issues.TypeManual) {
+			_ = p.Issues().AddLabels(ctx, num, []string{issues.StatusReady})
+			continue
+		}
 
 		if dispatched >= remaining {
 			// At capacity — just mark ready, don't dispatch

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -1124,6 +1124,9 @@ func TestAdvance_SkipsManualTasks(t *testing.T) {
 	assert.Equal(t, 1, result.DispatchedCount)
 	assert.Len(t, wf.dispatched, 1)
 	assert.Equal(t, "12", wf.dispatched[0]["issue_number"])
+	// Manual task should be unblocked (blocked removed, ready added)
+	assert.Contains(t, issueSvc.removedLabels[11], issues.StatusBlocked)
+	assert.Contains(t, issueSvc.addedLabels[11], issues.StatusReady)
 }
 
 func TestAdvance_ClosedIssueCountsAsComplete(t *testing.T) {


### PR DESCRIPTION
## Summary
- Manual tasks now get their label changed from `blocked` to `ready` when their tier is reached
- They are still not dispatched to workers — humans close them manually
- Added test assertion verifying the label change

## Problem
Manual tasks stayed `blocked` forever because the advance logic skipped them entirely before updating labels.

## Test plan
- [x] `TestAdvance_SkipsManualTasks` verifies label change and no dispatch
- [x] All tests pass