### PR TITLE
Trigger agent review when last tier completes via issue close

### DIFF
--- a/internal/cli/integrator.go
+++ b/internal/cli/integrator.go
@@ -146,6 +146,7 @@ func newAdvanceCmd() *cobra.Command {
 func newIntegratorReviewCmd() *cobra.Command {
 	var runID int64
 	var prNumber int
+	var batchNum int
 
 	cmd := &cobra.Command{
 		Use:   "review",
@@ -154,11 +155,15 @@ func newIntegratorReviewCmd() *cobra.Command {
 			if os.Getenv("HERD_RUNNER") != "true" {
 				return fmt.Errorf("herd integrator review is intended to run inside GitHub Actions (set HERD_RUNNER=true)")
 			}
-			if runID == 0 && prNumber == 0 {
-				return fmt.Errorf("either --run-id or --pr is required")
+			set := 0
+			if runID != 0 { set++ }
+			if prNumber != 0 { set++ }
+			if batchNum != 0 { set++ }
+			if set == 0 {
+				return fmt.Errorf("one of --run-id, --pr, or --batch is required")
 			}
-			if runID != 0 && prNumber != 0 {
-				return fmt.Errorf("--run-id and --pr are mutually exclusive")
+			if set > 1 {
+				return fmt.Errorf("--run-id, --pr, and --batch are mutually exclusive")
 			}
 
 			cfg, err := config.Load(".")
@@ -186,9 +191,10 @@ func newIntegratorReviewCmd() *cobra.Command {
 			g := git.New(cwd)
 
 			result, err := integrator.Review(cmd.Context(), client, ag, g, cfg, integrator.ReviewParams{
-				RunID:    runID,
-				PRNumber: prNumber,
-				RepoRoot: cwd,
+				RunID:       runID,
+				PRNumber:    prNumber,
+				BatchNumber: batchNum,
+				RepoRoot:    cwd,
 			})
 			if err != nil {
 				return err
@@ -206,7 +212,8 @@ func newIntegratorReviewCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Int64Var(&runID, "run-id", 0, "Workflow run ID")
-	cmd.Flags().IntVar(&prNumber, "pr", 0, "PR number (alternative to --run-id)")
+	cmd.Flags().IntVar(&prNumber, "pr", 0, "PR number")
+	cmd.Flags().IntVar(&batchNum, "batch", 0, "Batch/milestone number")
 	return cmd
 }
 

--- a/internal/cli/integrator_test.go
+++ b/internal/cli/integrator_test.go
@@ -38,13 +38,13 @@ func TestIntegratorReviewCmd_RequiresRunIDOrPR(t *testing.T) {
 	root.SetArgs([]string{"integrator", "review"})
 	err := root.Execute()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "either --run-id or --pr is required")
+	assert.Contains(t, err.Error(), "one of --run-id, --pr, or --batch is required")
 }
 
 func TestIntegratorReviewCmd_MutuallyExclusive(t *testing.T) {
 	t.Setenv("HERD_RUNNER", "true")
 	root := NewRootCmd()
-	root.SetArgs([]string{"integrator", "review", "--run-id", "100", "--pr", "50"})
+	root.SetArgs([]string{"integrator", "review", "--run-id", "100", "--batch", "1"})
 	err := root.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")

--- a/internal/cli/workflows/herd-integrator.yml
+++ b/internal/cli/workflows/herd-integrator.yml
@@ -58,11 +58,16 @@ jobs:
         env:
           HERD_RUNNER: "true"
           GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           BATCH=$(echo "$ISSUE_BODY" | grep -oP '^\s*batch:\s*\K[0-9]+' | head -1)
           if [ -n "$BATCH" ]; then
             herd integrator advance --batch "$BATCH"
+            herd integrator review --batch "$BATCH"
           else
             echo "Not a herd issue — skipping."
           fi

--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -46,9 +46,10 @@ type AdvanceResult struct {
 
 // ReviewParams holds the parameters for reviewing a batch PR.
 type ReviewParams struct {
-	RunID    int64
-	PRNumber int    // Alternative to RunID — used by pull_request_review trigger
-	RepoRoot string
+	RunID       int64
+	PRNumber    int    // Alternative to RunID — used by pull_request_review trigger
+	BatchNumber int    // Alternative to RunID — used by advance-on-close
+	RepoRoot    string
 }
 
 // ReviewResult holds the result of a batch PR review.

--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -44,6 +44,23 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 			return nil, fmt.Errorf("getting milestone #%d: %w", msNumber, err)
 		}
 		ms = got_ms
+	} else if params.BatchNumber > 0 {
+		// Batch-based lookup — used by advance-on-close
+		got_ms, err := p.Milestones().Get(ctx, params.BatchNumber)
+		if err != nil {
+			return nil, fmt.Errorf("getting milestone #%d: %w", params.BatchNumber, err)
+		}
+		ms = got_ms
+		batchBranch = fmt.Sprintf("herd/batch/%d-%s", ms.Number, planner.Slugify(ms.Title))
+
+		prs, err := p.PullRequests().List(ctx, platform.PRFilters{State: "open", Head: batchBranch})
+		if err != nil {
+			return nil, fmt.Errorf("listing batch PRs: %w", err)
+		}
+		if len(prs) == 0 {
+			return &ReviewResult{}, nil // No batch PR yet
+		}
+		pr = prs[0]
 	} else {
 		// Run-based lookup — used by workflow_run trigger
 		run, err := p.Workflows().GetRun(ctx, params.RunID)

--- a/internal/integrator/review_test.go
+++ b/internal/integrator/review_test.go
@@ -387,6 +387,62 @@ func TestReview_ByPRNumber(t *testing.T) {
 	assert.Equal(t, 50, result.BatchPRNumber)
 }
 
+func TestReview_BatchLookup(t *testing.T) {
+	issueSvc := newMockIssueService()
+	issueSvc.listResult = []*platform.Issue{}
+
+	mock := &mockPlatform{
+		issues: issueSvc,
+		prs: &mockPRService{
+			listResult: []*platform.PullRequest{{Number: 60, Title: "[herd] Batch", Head: "herd/batch/1-batch"}},
+		},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+		milestones: &mockMilestoneService{
+			getResult: map[int]*platform.Milestone{
+				1: {Number: 1, Title: "Batch"},
+			},
+		},
+	}
+
+	ag := &mockReviewAgent{
+		reviewResult: &agent.ReviewResult{Approved: true, Summary: "LGTM"},
+	}
+
+	dir, g := initTestRepo(t)
+	result, err := Review(context.Background(), mock, ag, g, &config.Config{
+		Integrator: config.Integrator{Review: true, ReviewMaxFixCycles: 3},
+	}, ReviewParams{BatchNumber: 1, RepoRoot: dir})
+
+	require.NoError(t, err)
+	assert.True(t, result.Approved)
+	assert.Equal(t, 60, result.BatchPRNumber)
+}
+
+func TestReview_BatchLookup_NoPR(t *testing.T) {
+	mock := &mockPlatform{
+		issues: newMockIssueService(),
+		prs: &mockPRService{
+			listResult: []*platform.PullRequest{},
+		},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+		milestones: &mockMilestoneService{
+			getResult: map[int]*platform.Milestone{
+				5: {Number: 5, Title: "My Feature"},
+			},
+		},
+	}
+
+	result, err := Review(context.Background(), mock, &mockReviewAgent{}, nil, &config.Config{
+		Integrator: config.Integrator{Review: true},
+	}, ReviewParams{BatchNumber: 5, RepoRoot: t.TempDir()})
+
+	require.NoError(t, err)
+	assert.False(t, result.Approved)
+	assert.Equal(t, 0, result.BatchPRNumber)
+}
+
 func TestReview_AutoMergeFailure(t *testing.T) {
 	issueSvc := newMockIssueService()
 	issueSvc.getResult[42] = &platform.Issue{


### PR DESCRIPTION
## Summary
- advance-on-close workflow job now runs `herd integrator review --batch` after advancing
- Added `--batch` flag to review CLI command (alongside existing `--run-id` and `--pr`)
- Added `BatchNumber` to `ReviewParams` with milestone-based PR lookup

## Problem
When the last tier completed via a manual issue close, the advance-on-close job only ran `advance` but not `review`. The review was only triggered by the `integrate` job on `workflow_run` events.

## Test plan
- [x] `TestReview_BatchLookup` — batch-based review finds PR and approves
- [x] `TestReview_BatchLookup_NoPR` — no-ops when no batch PR exists
- [x] CLI tests updated for new flag validation
- [x] All tests pass