### PR TITLE
Event-driven CI failure detection with monitor fallback

### DIFF
--- a/internal/cli/integrator.go
+++ b/internal/cli/integrator.go
@@ -307,6 +307,7 @@ func runWasSuccessful(ctx context.Context, client platform.Platform, runID int64
 
 func newIntegratorCheckCICmd() *cobra.Command {
 	var runID int64
+	var batchNum int
 
 	cmd := &cobra.Command{
 		Use:   "check-ci",
@@ -314,6 +315,12 @@ func newIntegratorCheckCICmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if os.Getenv("HERD_RUNNER") != "true" {
 				return fmt.Errorf("herd integrator check-ci is intended to run inside GitHub Actions (set HERD_RUNNER=true)")
+			}
+			if runID == 0 && batchNum == 0 {
+				return fmt.Errorf("one of --run-id or --batch is required")
+			}
+			if runID != 0 && batchNum != 0 {
+				return fmt.Errorf("--run-id and --batch are mutually exclusive")
 			}
 
 			cfg, err := config.Load(".")
@@ -325,19 +332,22 @@ func newIntegratorCheckCICmd() *cobra.Command {
 				return fmt.Errorf("creating GitHub client: %w", err)
 			}
 
-			ok, err := runWasSuccessful(cmd.Context(), client, runID)
-			if err != nil {
-				return fmt.Errorf("checking run status: %w", err)
-			}
-			if !ok {
-				fmt.Println("Skipped: triggering run was not successful.")
-				return nil
+			if runID != 0 {
+				ok, err := runWasSuccessful(cmd.Context(), client, runID)
+				if err != nil {
+					return fmt.Errorf("checking run status: %w", err)
+				}
+				if !ok {
+					fmt.Println("Skipped: triggering run was not successful.")
+					return nil
+				}
 			}
 
 			cwd, _ := os.Getwd()
 			result, err := integrator.CheckCI(cmd.Context(), client, cfg, integrator.CheckCIParams{
-				RunID:    runID,
-				RepoRoot: cwd,
+				RunID:       runID,
+				BatchNumber: batchNum,
+				RepoRoot:    cwd,
 			})
 			if err != nil {
 				return err
@@ -356,7 +366,7 @@ func newIntegratorCheckCICmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64Var(&runID, "run-id", 0, "Workflow run ID (required)")
-	cmd.MarkFlagRequired("run-id")
+	cmd.Flags().Int64Var(&runID, "run-id", 0, "Workflow run ID")
+	cmd.Flags().IntVar(&batchNum, "batch", 0, "Batch/milestone number")
 	return cmd
 }

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -43,8 +43,8 @@ func newPatrolCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Patrol complete: %d stale, %d failed, %d redispatched, %d escalated, %d stuck PRs\n",
-				result.StaleIssues, result.FailedIssues, result.RedispatchedCount, result.EscalatedCount, result.StuckPRs)
+			fmt.Printf("Patrol complete: %d stale, %d failed, %d redispatched, %d escalated, %d stuck PRs, %d CI failures\n",
+				result.StaleIssues, result.FailedIssues, result.RedispatchedCount, result.EscalatedCount, result.StuckPRs, result.CIFailures)
 			return nil
 		},
 	}

--- a/internal/cli/workflows/herd-integrator.yml
+++ b/internal/cli/workflows/herd-integrator.yml
@@ -3,6 +3,8 @@ on:
   workflow_run:
     workflows: ["HerdOS Worker"]
     types: [completed]
+  check_suite:
+    types: [completed]
   pull_request_review:
     types: [submitted]
   pull_request:
@@ -43,6 +45,36 @@ jobs:
           herd integrator check-ci --run-id "$RUN_ID"
           herd integrator advance --run-id "$RUN_ID"
           herd integrator review --run-id "$RUN_ID"
+
+  check-ci-on-completion:
+    if: >
+      vars.HERD_ENABLED == 'true'
+      && github.event_name == 'check_suite'
+      && github.event.check_suite.conclusion == 'failure'
+      && startsWith(github.event.check_suite.head_branch, 'herd/batch/')
+    runs-on: [self-hosted, '${{ vars.HERD_RUNNER_LABEL || ''herd-worker'' }}']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.check_suite.head_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Check CI and dispatch fix workers
+        env:
+          HERD_RUNNER: "true"
+          GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
+        run: |
+          BATCH=$(echo "$HEAD_BRANCH" | grep -oP 'herd/batch/\K[0-9]+')
+          if [ -n "$BATCH" ]; then
+            herd integrator check-ci --batch "$BATCH"
+          fi
 
   advance-on-close:
     if: vars.HERD_ENABLED == 'true' && github.event_name == 'issues'

--- a/internal/integrator/ci.go
+++ b/internal/integrator/ci.go
@@ -13,8 +13,9 @@ import (
 
 // CheckCIParams holds parameters for CI failure handling.
 type CheckCIParams struct {
-	RunID    int64
-	RepoRoot string
+	RunID       int64
+	BatchNumber int // Alternative to RunID — used by check_suite trigger
+	RepoRoot    string
 }
 
 // CheckCIResult holds the result of CI checking.
@@ -34,28 +35,41 @@ func CheckCI(ctx context.Context, p platform.Platform, cfg *config.Config, param
 		return &CheckCIResult{Skipped: true}, nil
 	}
 
-	// Resolve the batch branch from the run
-	run, err := p.Workflows().GetRun(ctx, params.RunID)
-	if err != nil {
-		return nil, fmt.Errorf("getting run %d: %w", params.RunID, err)
-	}
+	var ms *platform.Milestone
+	var batchBranch string
 
-	issueNumStr := run.Inputs["issue_number"]
-	issueNumber, err := strconv.Atoi(issueNumStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid issue_number: %w", err)
-	}
+	if params.BatchNumber > 0 {
+		// Batch-based lookup — used by check_suite trigger
+		got, err := p.Milestones().Get(ctx, params.BatchNumber)
+		if err != nil {
+			return nil, fmt.Errorf("getting milestone #%d: %w", params.BatchNumber, err)
+		}
+		ms = got
+		batchBranch = fmt.Sprintf("herd/batch/%d-%s", ms.Number, planner.Slugify(ms.Title))
+	} else {
+		// Run-based lookup — used by workflow_run trigger
+		run, err := p.Workflows().GetRun(ctx, params.RunID)
+		if err != nil {
+			return nil, fmt.Errorf("getting run %d: %w", params.RunID, err)
+		}
 
-	issue, err := p.Issues().Get(ctx, issueNumber)
-	if err != nil {
-		return nil, fmt.Errorf("getting issue #%d: %w", issueNumber, err)
-	}
-	if issue.Milestone == nil {
-		return nil, fmt.Errorf("issue #%d has no milestone", issueNumber)
-	}
+		issueNumStr := run.Inputs["issue_number"]
+		issueNumber, err := strconv.Atoi(issueNumStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid issue_number: %w", err)
+		}
 
-	ms := issue.Milestone
-	batchBranch := fmt.Sprintf("herd/batch/%d-%s", ms.Number, planner.Slugify(ms.Title))
+		issue, err := p.Issues().Get(ctx, issueNumber)
+		if err != nil {
+			return nil, fmt.Errorf("getting issue #%d: %w", issueNumber, err)
+		}
+		if issue.Milestone == nil {
+			return nil, fmt.Errorf("issue #%d has no milestone", issueNumber)
+		}
+
+		ms = issue.Milestone
+		batchBranch = fmt.Sprintf("herd/batch/%d-%s", ms.Number, planner.Slugify(ms.Title))
+	}
 
 	// Get CI status
 	status, err := p.Checks().GetCombinedStatus(ctx, batchBranch)

--- a/internal/integrator/ci_test.go
+++ b/internal/integrator/ci_test.go
@@ -194,3 +194,88 @@ func TestCheckCI(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckCI_BatchLookup(t *testing.T) {
+	issueSvc := newMockIssueService()
+	issueSvc.listResult = []*platform.Issue{}
+
+	prSvc := &mockPRService{
+		listResult: []*platform.PullRequest{
+			{Number: 50, Title: "[herd] Batch", Head: "herd/batch/1-batch"},
+		},
+	}
+
+	checkSvc := &mockCheckService{status: "success"}
+
+	mock := &mockPlatformWithChecks{
+		mockPlatform: &mockPlatform{
+			issues:    issueSvc,
+			prs:       prSvc,
+			workflows: &mockWorkflowService{},
+			repo:      &mockRepoService{defaultBranch: "main"},
+			milestones: &mockMilestoneService{
+				getResult: map[int]*platform.Milestone{
+					1: {Number: 1, Title: "Batch"},
+				},
+			},
+		},
+		checks: checkSvc,
+	}
+
+	result, err := CheckCI(context.Background(), mock, &config.Config{
+		Integrator: config.Integrator{RequireCI: true, CIMaxFixCycles: 2},
+		Workers:    config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"},
+	}, CheckCIParams{BatchNumber: 1})
+
+	require.NoError(t, err)
+	assert.Equal(t, "success", result.Status)
+}
+
+func TestCheckCI_BatchLookup_Failure(t *testing.T) {
+	issueSvc := newMockIssueService()
+	issueSvc.listResult = []*platform.Issue{}
+
+	createdIssues := []*platform.Issue{}
+	mockCreate := &mockIssueServiceWithCreate{
+		mockIssueService: issueSvc,
+		onCreate: func(title, body string, labels []string, milestone *int) (*platform.Issue, error) {
+			iss := &platform.Issue{Number: 99, Title: title}
+			createdIssues = append(createdIssues, iss)
+			return iss, nil
+		},
+	}
+
+	prSvc := &mockPRService{
+		listResult: []*platform.PullRequest{
+			{Number: 50, Title: "[herd] Batch", Head: "herd/batch/1-batch"},
+		},
+	}
+
+	wf := &mockWorkflowService{}
+	checkSvc := &mockCheckService{status: "failure", rerunErr: fmt.Errorf("re-run failed")}
+
+	mock := &mockPlatformWithChecks{
+		mockPlatform: &mockPlatform{
+			issues:    mockCreate,
+			prs:       prSvc,
+			workflows: wf,
+			repo:      &mockRepoService{defaultBranch: "main"},
+			milestones: &mockMilestoneService{
+				getResult: map[int]*platform.Milestone{
+					1: {Number: 1, Title: "Batch"},
+				},
+			},
+		},
+		checks: checkSvc,
+	}
+
+	result, err := CheckCI(context.Background(), mock, &config.Config{
+		Integrator: config.Integrator{RequireCI: true, CIMaxFixCycles: 2},
+		Workers:    config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"},
+	}, CheckCIParams{BatchNumber: 1})
+
+	require.NoError(t, err)
+	assert.Equal(t, "failure", result.Status)
+	assert.Len(t, createdIssues, 1)
+	assert.Len(t, result.FixIssues, 1)
+}

--- a/internal/monitor/patrol.go
+++ b/internal/monitor/patrol.go
@@ -19,6 +19,7 @@ type PatrolResult struct {
 	RedispatchedCount int
 	EscalatedCount    int
 	StuckPRs          int
+	CIFailures        int
 }
 
 const monitorCommentSignature = "**HerdOS Monitor Alert**"
@@ -171,9 +172,36 @@ func Patrol(ctx context.Context, p platform.Platform, cfg *config.Config) (*Patr
 			}
 			result.StuckPRs++
 		}
+
+		// CI failure detection on batch PRs
+		if cfg.Integrator.RequireCI && strings.HasPrefix(pr.Head, "herd/batch/") {
+			ciStatus, err := p.Checks().GetCombinedStatus(ctx, pr.Head)
+			if err == nil && ciStatus == "failure" {
+				if !hasCIMonitorComment(ctx, p, pr.Number) {
+					_ = p.PullRequests().AddComment(ctx, pr.Number, fmt.Sprintf(
+						"⚠️ **HerdOS Monitor Alert**\n\nCI is failing on batch branch `%s`. The integrator should have dispatched a fix worker. If this persists, manual intervention may be needed.\n\n%s",
+						pr.Head, buildMentions(cfg.Monitor.NotifyUsers)))
+				}
+				result.CIFailures++
+			}
+		}
 	}
 
 	return result, nil
+}
+
+func hasCIMonitorComment(ctx context.Context, p platform.Platform, prNumber int) bool {
+	// PR comments are issue comments in GitHub
+	comments, err := p.Issues().ListComments(ctx, prNumber)
+	if err != nil {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c.Body, monitorCommentSignature) && strings.Contains(c.Body, "CI is failing") {
+			return true
+		}
+	}
+	return false
 }
 
 // BackoffDelay returns the backoff delay for a given failure count.

--- a/internal/monitor/patrol_test.go
+++ b/internal/monitor/patrol_test.go
@@ -20,6 +20,7 @@ type mockPlatform struct {
 	prs       *mockPRService
 	workflows *mockWorkflowService
 	repo      *mockRepoService
+	checks    *mockCheckService
 }
 
 func (m *mockPlatform) Issues() platform.IssueService             { return m.issues }
@@ -29,7 +30,23 @@ func (m *mockPlatform) Labels() platform.LabelService              { return nil 
 func (m *mockPlatform) Milestones() platform.MilestoneService      { return nil }
 func (m *mockPlatform) Runners() platform.RunnerService            { return nil }
 func (m *mockPlatform) Repository() platform.RepositoryService     { return m.repo }
-func (m *mockPlatform) Checks() platform.CheckService             { return nil }
+func (m *mockPlatform) Checks() platform.CheckService {
+	if m.checks != nil {
+		return m.checks
+	}
+	return &mockCheckService{status: "success"}
+}
+
+type mockCheckService struct {
+	status string
+}
+
+func (m *mockCheckService) GetCombinedStatus(_ context.Context, _ string) (string, error) {
+	return m.status, nil
+}
+func (m *mockCheckService) RerunFailedChecks(_ context.Context, _ string) error {
+	return nil
+}
 
 type mockIssueService struct {
 	listResults    map[string][]*platform.Issue // keyed by label
@@ -370,6 +387,82 @@ func TestPatrol_StuckPR(t *testing.T) {
 	assert.Len(t, prSvc.comments[10], 1)
 	assert.Contains(t, prSvc.comments[10][0], "open for over 48 hours")
 	assert.Len(t, prSvc.comments[11], 0) // non-herd PR not flagged
+}
+
+func TestPatrol_CIFailureOnBatchPR(t *testing.T) {
+	prSvc := newMockPRService()
+	prSvc.listResult = []*platform.PullRequest{
+		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
+	}
+
+	issueSvc := newMockIssueService()
+
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       prSvc,
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+		checks:    &mockCheckService{status: "failure"},
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{RequireCI: true},
+	}
+
+	result, err := Patrol(context.Background(), mock, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.CIFailures)
+	assert.Len(t, prSvc.comments[10], 1)
+	assert.Contains(t, prSvc.comments[10][0], "CI is failing")
+}
+
+func TestPatrol_CIPassingOnBatchPR(t *testing.T) {
+	prSvc := newMockPRService()
+	prSvc.listResult = []*platform.PullRequest{
+		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
+	}
+
+	issueSvc := newMockIssueService()
+
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       prSvc,
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+		checks:    &mockCheckService{status: "success"},
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{RequireCI: true},
+	}
+
+	result, err := Patrol(context.Background(), mock, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.CIFailures)
+	assert.Len(t, prSvc.comments[10], 0)
+}
+
+func TestPatrol_CINotCheckedWhenRequireCIFalse(t *testing.T) {
+	prSvc := newMockPRService()
+	prSvc.listResult = []*platform.PullRequest{
+		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
+	}
+
+	mock := &mockPlatform{
+		issues:    newMockIssueService(),
+		prs:       prSvc,
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+		checks:    &mockCheckService{status: "failure"},
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{RequireCI: false},
+	}
+
+	result, err := Patrol(context.Background(), mock, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.CIFailures)
 }
 
 func TestBackoffDelay(t *testing.T) {


### PR DESCRIPTION
## Summary
- New `check-ci-on-completion` job in integrator workflow triggers on `check_suite:completed` for failed batch branches
- Added `--batch` flag to `check-ci` CLI command
- Monitor patrol now checks CI status on open batch PRs and comments alerts
- `CheckCIParams` supports `BatchNumber` for milestone-based lookup

## Problem
The existing `check-ci` step ran immediately after consolidation when CI was always `pending`. By the time CI failed, nothing re-triggered the check.

## Test plan
- [x] `TestCheckCI_BatchLookup` — batch-based lookup with passing CI
- [x] `TestCheckCI_BatchLookup_Failure` — batch-based lookup dispatches fix worker
- [x] `TestPatrol_CIFailureOnBatchPR` — monitor detects and comments on CI failure
- [x] `TestPatrol_CIPassingOnBatchPR` — no alert when CI passes
- [x] `TestPatrol_CINotCheckedWhenRequireCIFalse` — respects config
- [x] All tests pass