### PR TITLE
Update docs and planner for recent changes

### DIFF
--- a/.herd/planner.md
+++ b/.herd/planner.md
@@ -2,3 +2,4 @@
 - Use table-driven tests where applicable.
 - Include full function signatures and struct definitions, not just descriptions.
 - Specify which packages to import and which existing helpers to reuse.
+- Every batch must include a final-tier task to review and update documentation in `docs/`. Check if existing docs need updating to reflect the changes, and whether new docs are needed for new features. This task depends on all other tasks in the batch.

--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -439,11 +439,12 @@ with 👤 in status output.
 Manual tasks participate fully in the DAG:
 
 - **Not dispatched** -- `herd dispatch` skips them
+- **Unblocked on tier advancement** -- when the previous tier completes, manual tasks transition from `blocked` to `ready` like any other task, but are not dispatched to workers
 - **Completed by closing** -- a human closes the issue (or labels it
   `herd/status:done`); the Integrator's `advance-on-close` job detects the
-  close event and checks if the tier is now complete
+  close event, advances the tier, and runs agent review if all tiers are done
 - **Tier-aware** -- if a manual task is in Tier 0, Tier 1 won't dispatch until
-  it's closed; avoid putting manual tasks on the critical path when possible
+  it's closed. Manual tasks that grant permissions or set up external services should always be in Tier 0 so they unblock automated tasks that depend on them
 - **Notifications** -- when `notify_users` is configured, the Planner @mentions
   those users on manual task issues for visibility
 
@@ -479,10 +480,14 @@ Worker pushes to worker branch
 Integrator consolidates into batch branch
         |
         v
-CI runs on the updated batch branch, tests fail
+CI runs on the updated batch branch
         |
         v
-Re-run the failed Action (transient/flaky failure filter)
+check_suite.completed event triggers the Integrator
+        |
+        +-- CI passed --> done, continue normally
+        |
+        +-- CI failed --> Re-run the failed checks (transient/flaky failure filter)
         |
         +-- Passes --> done, continue normally
         |

--- a/docs/design/github-integration.md
+++ b/docs/design/github-integration.md
@@ -83,7 +83,7 @@ HerdOS ships three workflow files, installed by `herd init` into `.github/workfl
 |----------|---------|---------|
 | `herd-worker.yml` | `workflow_dispatch` | Executes a task from an issue. Receives issue number, batch branch, timeout, and runner label as inputs. Checks out the batch branch (or main), runs `herd worker exec`, which handles reading the issue, labeling, branching, invoking the agent, pushing, and updating status. |
 | `herd-monitor.yml` | `schedule` (cron, every 15 min) + `workflow_dispatch` | Health patrol. Runs `herd monitor patrol` to detect stuck/failed work, re-dispatch if configured, comment on issues, and unblock stragglers. Does not need an agent -- only makes API calls. |
-| `herd-integrator.yml` | `workflow_run` (worker completed) + `pull_request_review` (submitted) | Consolidates worker branches into the batch branch, checks tier completion, dispatches next tier, opens the batch PR when all tiers are done, runs agent review, and merges after human approval. |
+| `herd-integrator.yml` | `workflow_run` (worker completed) + `check_suite` (CI completed) + `issues` (closed) + `pull_request_review` (submitted) + `pull_request` (closed) | Consolidates worker branches into the batch branch, checks tier completion, dispatches next tier, opens the batch PR when all tiers are done, detects CI failures and dispatches fix workers, runs agent review, and merges after human approval. |
 
 ### Secrets Management
 
@@ -105,13 +105,17 @@ Worker completes   -> workflow_run.completed  -> Integrator consolidates
                                                       |
 Tier complete      -> (integrator logic)      -> Dispatch next tier
                                                       |
+Manual task closed -> issues.closed           -> Integrator advances + reviews
+                                                      |
 All tiers done     -> (integrator logic)      -> Batch PR opened
+                                                      |
+CI fails on batch  -> check_suite.completed   -> Integrator dispatches fix worker
                                                       |
 Agent review       -> (integrator logic)      -> Approve or fix cycle
                                                       |
 Human approves PR  -> pull_request_review     -> Integrator merges (if CI passes)
                                                       |
-Batch PR merged    -> pull_request.closed     -> Issues closed
+Batch PR merged    -> pull_request.closed     -> Issues closed, cleanup
                                                       |
 Cron fires         -> schedule                -> Monitor patrols
 Worker fails       -> workflow_dispatch       -> Monitor patrols (immediate)
@@ -121,8 +125,15 @@ Worker fails       -> workflow_dispatch       -> Monitor patrols (immediate)
 
 - **workflow_dispatch** -- primary dispatch mechanism. Only users with write access can trigger it (enforced by GitHub). The `ref` parameter points to the branch containing the workflow YAML, not the branch the worker checks out.
 - **workflow_run** -- triggers the Integrator when a worker completes (success or failure).
+- **check_suite** -- triggers the Integrator when CI completes on a batch branch. If CI failed, the Integrator re-runs checks once (transient failure filter), then dispatches fix workers up to `ci_max_fix_cycles`.
+- **issues** -- triggers the Integrator when an issue is closed. Used for manual task completion — the Integrator advances the tier and runs agent review if all tiers are done.
 - **pull_request_review** -- triggers the Integrator to merge batch PRs after human approval + CI pass.
+- **pull_request** -- triggers cleanup when a batch PR is merged (branch deletion, milestone closure).
 - **schedule** -- triggers Monitor patrol. GitHub may delay or skip scheduled runs under load; the Monitor is stateless and catches up on the next patrol.
+
+All workflows require the `HERD_ENABLED` repository variable to be set to `true`. This prevents workflow storms when `herd init` pushes workflow files before runners are configured. All `${{ }}` expressions in `run:` blocks are passed through environment variables to prevent shell injection.
+
+The checkout action in all workflows uses `HERD_GITHUB_TOKEN` (falling back to `GITHUB_TOKEN`) to configure git credentials for pushes. This is required for workers that create workflow files, which need the `workflows` permission.
 
 Issues auto-close via GitHub's native "Closes #N" references in the batch PR description. Dependency unblocking is handled by the Integrator's tier advancement logic, with the Monitor as a safety net.
 

--- a/docs/design/planner.md
+++ b/docs/design/planner.md
@@ -41,6 +41,20 @@ Good decomposition is critical. The Planner should produce tasks that:
 
 The interactive session is key to achieving these properties. The agent has full codebase context and can reason about file boundaries, dependency relationships, and potential conflicts before producing a plan.
 
+## Worker Permissions and Manual Tasks
+
+Workers run as GitHub Actions with limited permissions. They can read/write repository contents, issues, and PRs. They **cannot**: create or modify GitHub Actions workflow files (`.github/workflows/`), manage secrets or repo settings, create repos, or interact with external services requiring authentication.
+
+The Planner evaluates each task against these boundaries. Any task requiring elevated permissions or external setup must be marked as **manual** (`"manual": true`). Manual tasks are tracked as GitHub Issues but not dispatched to workers — a human must complete and close them.
+
+**Manual tasks that grant permissions or set up external services must be in Tier 0.** These tasks unblock later tiers. If a worker needs a secret, API key, DNS record, or workflow permission to do its job, the manual task that provides it must complete first. Never place a setup task in a later tier than the tasks that depend on it.
+
+Common manual tasks:
+- Creating or modifying CI/CD workflow files
+- Configuring external services (DNS, CDN, cloud providers, APIs)
+- Setting up secrets, tokens, or environment variables
+- Creating repositories or managing GitHub settings
+
 ## Self-Contained Issues
 
 **The Planner does the thinking, the Worker does the typing.**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,17 @@ This will:
 3. **Create GitHub labels** — the `herd/*` label taxonomy used to track issue status and type
 4. **Install workflow files** — GitHub Actions workflows for workers, integrator, and monitor in `.github/workflows/`
 5. **Create runner files** — `Dockerfile.runner`, `entrypoint.sh`, `docker-compose.herd.yml`, and `.env.example` for self-hosted runner setup
+6. **Commit and open a PR** — creates a `herd/init-<version>` branch, commits all generated files, pushes, and opens a PR. Review and merge the PR to apply the changes.
+
+### Enable Workflows
+
+Workflows are installed but inactive until you enable them. After setting up runners (see [Runner Setup](runners.md)), set the `HERD_ENABLED` repository variable:
+
+```bash
+gh variable set HERD_ENABLED --body true --repo <owner>/<repo>
+```
+
+This prevents a workflow storm if runners are online before the system is fully configured.
 
 ### Skipping Steps
 
@@ -149,9 +160,11 @@ Once workers are dispatched, the system runs autonomously via GitHub Actions:
 
 4. **Agent review** — If `integrator.review` is enabled, an agent reviews the batch PR diff against all acceptance criteria. If issues are found, the Integrator creates fix issues and dispatches fix workers. This cycle repeats up to `review_max_fix_cycles` times.
 
-5. **Monitor patrols** — A cron-triggered Action detects stale workers (in-progress with no active run), failed issues (auto-redispatches with exponential backoff), and stuck PRs (open longer than `max_pr_age_hours`). It escalates to `notify_users` when retries are exhausted.
+5. **CI failure detection** — When CI completes on the batch branch, a `check_suite` event triggers the Integrator. If CI failed, it re-runs checks once (transient failure filter), then dispatches fix workers up to `ci_max_fix_cycles`.
 
-6. **You review and merge** — The batch PR arrives with a summary table of all tasks and their tiers. If `pull_requests.auto_merge` is true and the agent review passed, it merges automatically.
+6. **Monitor patrols** — A cron-triggered Action detects stale workers (in-progress with no active run), failed issues (auto-redispatches with exponential backoff), CI failures on batch PRs, and stuck PRs (open longer than `max_pr_age_hours`). It escalates to `notify_users` when retries are exhausted.
+
+7. **You review and merge** — The batch PR arrives with a summary table of all tasks and their tiers. If `pull_requests.auto_merge` is true and the agent review passed, it merges automatically.
 
 ### Role Instruction Files
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,7 +78,7 @@ cd /path/to/your/repo
 herd init
 ```
 
-`herd init` creates a `herd/init` branch, commits the updated files, pushes, and opens a PR. Review and merge the PR to apply the changes. Configuration (`.herdos.yml`) and role instructions (`.herd/*.md`) are never overwritten.
+`herd init` creates a `herd/init-<version>` branch, commits the updated files, pushes, and opens a PR. Review and merge the PR to apply the changes. Configuration (`.herdos.yml`) and role instructions (`.herd/*.md`) are never overwritten.
 
 ### Update runner containers
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -7,13 +7,17 @@ HerdOS workers run as GitHub Actions on self-hosted runners. Self-hosted runners
 ## Quick Setup
 
 ```bash
-herd init                    # generates runner files + config
+herd init                    # generates runner files + config + PR
+# merge the PR created by herd init
 cp .env.example .env         # copy the env template
 # fill in .env (see sections below)
+docker compose -f docker-compose.herd.yml build
 docker compose -f docker-compose.herd.yml up -d
+# enable workflows after runners are online:
+gh variable set HERD_ENABLED --body true --repo <owner>/<repo>
 ```
 
-That's it. Three runners start by default (configurable in `docker-compose.herd.yml`).
+Three runners start by default (configurable in `docker-compose.herd.yml`). Workflows are inactive until `HERD_ENABLED` is set — this prevents a workflow storm from queued events firing before runners are ready.
 
 ## 1. GitHub Token
 
@@ -31,6 +35,7 @@ You need a Personal Access Token (PAT) for runner registration and API operation
    - **Contents**: Read and write
    - **Issues**: Read and write
    - **Pull requests**: Read and write
+   - **Workflows**: Read and write (required if workers create workflow files)
    - **Metadata**: Read (auto-selected)
 5. Generate and copy the token
 
@@ -38,7 +43,7 @@ You need a Personal Access Token (PAT) for runner registration and API operation
 
 1. Go to **Settings → Developer settings → Tokens (classic) → Generate new token**
    (https://github.com/settings/tokens)
-2. Select the `repo` scope
+2. Select the `repo` and `workflow` scopes
 3. Generate and copy the token
 
 ### Where to use it
@@ -115,6 +120,7 @@ Configure at **org level** (recommended for multi-repo) or **repo level**:
 | `HERD_GITHUB_TOKEN` | Secret | Yes | PAT for workflow dispatch, releases, cross-repo ops |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Secret | One of these | Agent auth — Pro/Max subscription |
 | `ANTHROPIC_API_KEY` | Secret | One of these | Agent auth — pay-per-token |
+| `HERD_ENABLED` | Variable | Yes | Activates workflows — set to `true` after runners are online |
 | `HERD_RUNNER_LABEL` | Variable | No | Override default runner label (default: `herd-worker`) |
 
 **Org secrets**: https://github.com/organizations/{org}/settings/secrets/actions — set visibility to "All repositories".
@@ -126,15 +132,17 @@ Configure at **org level** (recommended for multi-repo) or **repo level**:
 The generated `Dockerfile.runner` builds an Ubuntu 24.04 image with:
 
 - **GitHub Actions runner** (v2.332.0)
-- **Herd CLI** (installed from source via `go install`)
 - **Claude Code** (installed via npm)
 - **Tools**: curl, jq, git, gh, Node.js
 
+The **Herd CLI** is not baked into the image — it's downloaded at container startup by `entrypoint.sh`. This ensures runners always use the latest version without rebuilding. Set `HERD_VERSION` in `.env` to pin a specific version.
+
 The `entrypoint.sh` script handles runner lifecycle:
-1. Removes stale config from previous runs (ephemeral runners leave `.runner` behind on restart)
-2. Registers with GitHub using a short-lived registration token
-3. Starts the runner in ephemeral mode (picks up one job, then deregisters)
-4. On SIGTERM/SIGINT, deregisters cleanly
+1. Downloads the herd binary (latest or pinned version)
+2. Removes stale config from previous runs (ephemeral runners leave `.runner` behind on restart)
+3. Registers with GitHub using a short-lived registration token
+4. Starts the runner in ephemeral mode (picks up one job, then deregisters)
+5. On SIGTERM/SIGINT, deregisters cleanly
 
 The `docker-compose.herd.yml` runs the worker service with `restart: always`, so after each job completes the container restarts and re-registers for the next job.
 


### PR DESCRIPTION
## Summary
- Updates all docs to reflect PRs #72-#82 (workflow guard, CI detection, init changes, permissions, security)
- Adds planner instruction: every batch must include a final-tier docs review task

## Test plan
- [x] Build and tests pass
- [ ] Docs render correctly