### PR TITLE
Fix CI detection for external providers (Cloudflare, etc.)

### DIFF
--- a/docs/design/github-integration.md
+++ b/docs/design/github-integration.md
@@ -125,7 +125,7 @@ Worker fails       -> workflow_dispatch       -> Monitor patrols (immediate)
 
 - **workflow_dispatch** -- primary dispatch mechanism. Only users with write access can trigger it (enforced by GitHub). The `ref` parameter points to the branch containing the workflow YAML, not the branch the worker checks out.
 - **workflow_run** -- triggers the Integrator when a worker completes (success or failure).
-- **check_suite** -- triggers the Integrator when CI completes on a batch branch. If CI failed, the Integrator re-runs checks once (transient failure filter), then dispatches fix workers up to `ci_max_fix_cycles`.
+- **check_suite** -- triggers the Integrator when CI completes on a batch branch. If CI failed, the Integrator re-runs checks once (transient failure filter), then dispatches fix workers up to `ci_max_fix_cycles`. Note: `check_suite` events may not fire for external CI providers (e.g., Cloudflare Pages). The Monitor patrol serves as a fallback, checking CI status on open batch PRs every 15 minutes. CI status detection checks both GitHub's commit status API and the check runs API to support external providers.
 - **issues** -- triggers the Integrator when an issue is closed. Used for manual task completion — the Integrator advances the tier and runs agent review if all tiers are done.
 - **pull_request_review** -- triggers the Integrator to merge batch PRs after human approval + CI pass.
 - **pull_request** -- triggers cleanup when a batch PR is merged (branch deletion, milestone closure).

--- a/internal/platform/github/checks.go
+++ b/internal/platform/github/checks.go
@@ -13,11 +13,49 @@ var _ platform.CheckService = (*checkService)(nil)
 type checkService struct{ c *Client }
 
 func (s *checkService) GetCombinedStatus(ctx context.Context, ref string) (string, error) {
-	status, _, err := s.c.gh.Repositories.GetCombinedStatus(ctx, s.c.owner, s.c.repo, ref, nil)
+	// Check both commit statuses (older API) and check runs (newer API, used by
+	// external apps like Cloudflare). The combined result is the worst of the two.
+
+	// 1. Commit statuses
+	commitStatus, _, err := s.c.gh.Repositories.GetCombinedStatus(ctx, s.c.owner, s.c.repo, ref, nil)
 	if err != nil {
 		return "", fmt.Errorf("getting combined status for %s: %w", ref, err)
 	}
-	return status.GetState(), nil
+	statusState := commitStatus.GetState() // "success", "pending", "failure", or ""
+
+	// 2. Check runs
+	checkRuns, _, err := s.c.gh.Checks.ListCheckRunsForRef(ctx, s.c.owner, s.c.repo, ref, nil)
+	if err != nil {
+		return "", fmt.Errorf("listing check runs for %s: %w", ref, err)
+	}
+
+	checksState := ""
+	if checkRuns.GetTotal() > 0 {
+		checksState = "success"
+		for _, cr := range checkRuns.CheckRuns {
+			if cr.GetStatus() != "completed" {
+				checksState = "pending"
+				break
+			}
+			if cr.GetConclusion() == "failure" || cr.GetConclusion() == "cancelled" {
+				checksState = "failure"
+				break
+			}
+		}
+	}
+
+	// Combine: failure wins, then pending, then success
+	if statusState == "failure" || checksState == "failure" {
+		return "failure", nil
+	}
+	if statusState == "pending" || checksState == "pending" {
+		return "pending", nil
+	}
+	if statusState == "success" || checksState == "success" {
+		return "success", nil
+	}
+	// No statuses or check runs at all
+	return "success", nil
 }
 
 func (s *checkService) RerunFailedChecks(ctx context.Context, ref string) error {

--- a/internal/platform/github/checks_test.go
+++ b/internal/platform/github/checks_test.go
@@ -1,0 +1,162 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	gh "github.com/google/go-github/v68/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCombinedStatus_CommitStatusSuccess(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{Total: gh.Ptr(0)})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "success", status)
+}
+
+func TestGetCombinedStatus_CheckRunFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		// No commit statuses — empty/success
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
+			Total: gh.Ptr(1),
+			CheckRuns: []*gh.CheckRun{
+				{
+					Name:       gh.Ptr("Cloudflare Pages"),
+					Status:     gh.Ptr("completed"),
+					Conclusion: gh.Ptr("failure"),
+				},
+			},
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "failure", status)
+}
+
+func TestGetCombinedStatus_CheckRunPending(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
+			Total: gh.Ptr(1),
+			CheckRuns: []*gh.CheckRun{
+				{
+					Name:   gh.Ptr("Cloudflare Pages"),
+					Status: gh.Ptr("in_progress"),
+				},
+			},
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "pending", status)
+}
+
+func TestGetCombinedStatus_BothSucceed(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
+			Total: gh.Ptr(1),
+			CheckRuns: []*gh.CheckRun{
+				{
+					Name:       gh.Ptr("CI"),
+					Status:     gh.Ptr("completed"),
+					Conclusion: gh.Ptr("success"),
+				},
+			},
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "success", status)
+}
+
+func TestGetCombinedStatus_CommitStatusFailureOverridesCheckRunSuccess(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("failure")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
+			Total: gh.Ptr(1),
+			CheckRuns: []*gh.CheckRun{
+				{
+					Name:       gh.Ptr("CI"),
+					Status:     gh.Ptr("completed"),
+					Conclusion: gh.Ptr("success"),
+				},
+			},
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "failure", status)
+}
+
+func TestGetCombinedStatus_NoStatusesOrChecks(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{Total: gh.Ptr(0)})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "success", status)
+}
+
+func TestGetCombinedStatus_CheckRunCancelled(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
+			Total: gh.Ptr(1),
+			CheckRuns: []*gh.CheckRun{
+				{
+					Name:       gh.Ptr("CI"),
+					Status:     gh.Ptr("completed"),
+					Conclusion: gh.Ptr("cancelled"),
+				},
+			},
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "failure", status)
+}


### PR DESCRIPTION
## Summary
- `GetCombinedStatus` now checks both commit statuses and check runs APIs
- Failure from either source is reported as failure
- Documents `check_suite` limitation with external CI and monitor fallback

## Problem
Cloudflare Pages reports CI results via check runs, not commit statuses. The monitor patrol reported 0 CI failures because it only checked commit statuses.

## Test plan
- [x] `TestGetCombinedStatus_CommitStatusSuccess` — commit status only
- [x] `TestGetCombinedStatus_CheckRunFailure` — external CI failure detected
- [x] `TestGetCombinedStatus_CheckRunPending` — in-progress check run
- [x] `TestGetCombinedStatus_BothSucceed` — both APIs pass
- [x] `TestGetCombinedStatus_CommitStatusFailureOverridesCheckRunSuccess` — failure wins
- [x] `TestGetCombinedStatus_NoStatusesOrChecks` — empty = success
- [x] `TestGetCombinedStatus_CheckRunCancelled` — cancelled = failure
- [x] All tests pass