### PR TITLE
Fix conflict handling: block tier, mention users, default to dispatch-resolver

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -13,7 +13,7 @@ workers:
     timeout_minutes: 30
 integrator:
     strategy: squash
-    on_conflict: notify
+    on_conflict: dispatch-resolver
     max_conflict_resolution_attempts: 2
     require_ci: true
     review: true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -154,7 +154,7 @@ Once workers are dispatched, the system runs autonomously via GitHub Actions:
 
 1. **Workers execute** — Each worker reads its assigned issue, runs your agent in headless mode on a self-hosted runner, and pushes changes to a worker branch (`herd/worker/<number>-<slug>`). If no changes are needed, the worker marks the issue as done without pushing.
 
-2. **Integrator consolidates** — When a worker completes, the Integrator merges its branch into the batch branch (`herd/batch/<number>-<slug>`) and deletes the worker branch. If a merge conflict is detected, the behavior depends on `integrator.on_conflict`: with `notify` (default), a comment is posted for manual resolution; with `dispatch-resolver`, a conflict-resolution worker is automatically dispatched.
+2. **Integrator consolidates** — When a worker completes, the Integrator merges its branch into the batch branch (`herd/batch/<number>-<slug>`) and deletes the worker branch. If a merge conflict is detected, the behavior depends on `integrator.on_conflict`: with `dispatch-resolver` (default), a conflict-resolution worker is automatically dispatched; with `notify`, a comment is posted for manual resolution instead.
 
 3. **Integrator advances** — After consolidation, the Integrator checks if the current tier is complete. If so, it unblocks and dispatches the next tier. When all tiers are done, it rebases the batch branch onto `main` and opens a single batch PR.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,7 @@ func TestDefault(t *testing.T) {
 	assert.Equal(t, "herd-worker", cfg.Workers.RunnerLabel)
 	assert.Equal(t, 30, cfg.Workers.TimeoutMinutes)
 	assert.Equal(t, "squash", cfg.Integrator.Strategy)
-	assert.Equal(t, "notify", cfg.Integrator.OnConflict)
+	assert.Equal(t, "dispatch-resolver", cfg.Integrator.OnConflict)
 	assert.Equal(t, true, cfg.Integrator.RequireCI)
 	assert.Equal(t, true, cfg.Integrator.Review)
 	assert.Equal(t, 3, cfg.Integrator.ReviewMaxFixCycles)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -17,7 +17,7 @@ func Default() *Config {
 		},
 		Integrator: Integrator{
 			Strategy:                      "squash",
-			OnConflict:                    "notify",
+			OnConflict:                    "dispatch-resolver",
 			MaxConflictResolutionAttempts: 2,
 			RequireCI:                     true,
 			Review:                        true,

--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -130,10 +130,21 @@ func Consolidate(ctx context.Context, p platform.Platform, g *git.Git, cfg *conf
 			return handleConflictResolution(ctx, p, cfg, issue, issue.Milestone, workerBranch, batchBranch)
 		}
 
-		// Default: notify — comment on issue and return error
+		// Default: notify — comment on issue with @mentions and return error
+		mentions := ""
+		if len(cfg.Monitor.NotifyUsers) > 0 {
+			parts := make([]string, len(cfg.Monitor.NotifyUsers))
+			for i, u := range cfg.Monitor.NotifyUsers {
+				parts[i] = "@" + u
+			}
+			mentions = "\n\n/cc " + strings.Join(parts, " ")
+		}
 		_ = p.Issues().AddComment(ctx, issueNumber, fmt.Sprintf(
-			"⚠️ **HerdOS Integrator**\n\nMerge conflict detected when consolidating `%s` into `%s`.\n\nManual resolution required.",
-			workerBranch, batchBranch))
+			"⚠️ **HerdOS Integrator**\n\nMerge conflict detected when consolidating `%s` into `%s`.\n\nManual resolution required.%s",
+			workerBranch, batchBranch, mentions))
+		// Relabel from done → failed to block tier advancement
+		_ = p.Issues().RemoveLabels(ctx, issueNumber, []string{issues.StatusDone})
+		_ = p.Issues().AddLabels(ctx, issueNumber, []string{issues.StatusFailed})
 		return &ConsolidateResult{
 			IssueNumber:      issueNumber,
 			WorkerBranch:     workerBranch,
@@ -490,9 +501,20 @@ func handleConflictResolution(ctx context.Context, p platform.Platform, cfg *con
 	}
 
 	if conflictCount >= cfg.Integrator.MaxConflictResolutionAttempts {
+		mentions := ""
+		if len(cfg.Monitor.NotifyUsers) > 0 {
+			parts := make([]string, len(cfg.Monitor.NotifyUsers))
+			for i, u := range cfg.Monitor.NotifyUsers {
+				parts[i] = "@" + u
+			}
+			mentions = "\n\n/cc " + strings.Join(parts, " ")
+		}
 		_ = p.Issues().AddComment(ctx, issue.Number, fmt.Sprintf(
-			"⚠️ **HerdOS Integrator**\n\nMerge conflict detected but max resolution attempts (%d) reached. Manual intervention required.\n\nConflicting branches: `%s` ← `%s`",
-			cfg.Integrator.MaxConflictResolutionAttempts, batchBranch, workerBranch))
+			"⚠️ **HerdOS Integrator**\n\nMerge conflict detected but max resolution attempts (%d) reached. Manual intervention required.\n\nConflicting branches: `%s` ← `%s`%s",
+			cfg.Integrator.MaxConflictResolutionAttempts, batchBranch, workerBranch, mentions))
+		// Relabel from done → failed to block tier advancement
+		_ = p.Issues().RemoveLabels(ctx, issue.Number, []string{issues.StatusDone})
+		_ = p.Issues().AddLabels(ctx, issue.Number, []string{issues.StatusFailed})
 		return &ConsolidateResult{
 			IssueNumber:      issue.Number,
 			WorkerBranch:     workerBranch,
@@ -524,6 +546,10 @@ func handleConflictResolution(ctx context.Context, p platform.Platform, cfg *con
 	if err != nil {
 		return nil, fmt.Errorf("creating conflict-resolution issue: %w", err)
 	}
+
+	// Relabel original issue from done → failed to block tier advancement
+	_ = p.Issues().RemoveLabels(ctx, issue.Number, []string{issues.StatusDone})
+	_ = p.Issues().AddLabels(ctx, issue.Number, []string{issues.StatusFailed})
 
 	// Dispatch resolver worker
 	defaultBranch, _ := p.Repository().GetDefaultBranch(ctx)

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -582,6 +582,43 @@ func TestConsolidate_ConflictNotify(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, result.ConflictDetected)
 	assert.Contains(t, issueSvc.comments[42][0], "Merge conflict detected")
+	// Should relabel from done → failed to block tier advancement
+	assert.Contains(t, issueSvc.removedLabels[42], issues.StatusDone)
+	assert.Contains(t, issueSvc.addedLabels[42], issues.StatusFailed)
+}
+
+func TestConsolidate_ConflictNotify_MentionsUsers(t *testing.T) {
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = &platform.Issue{
+		Number: 42, Title: "Test",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	_, g := initConflictRepo(t)
+
+	mock := &mockPlatform{
+		issues: issueSvc,
+		workflows: &mockWorkflowService{
+			runs: map[int64]*platform.Run{
+				100: {ID: 100, Conclusion: "success", Inputs: map[string]string{"issue_number": "42"}},
+			},
+		},
+		repo: &mockRepoService{
+			defaultBranch: "main",
+			branchExists:  map[string]bool{"herd/worker/42-test": true},
+		},
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{OnConflict: "notify"},
+		Monitor:    config.Monitor{NotifyUsers: []string{"alice", "bob"}},
+	}
+
+	_, err := Consolidate(context.Background(), mock, g, cfg, ConsolidateParams{RunID: 100})
+	assert.Error(t, err)
+	assert.Contains(t, issueSvc.comments[42][0], "@alice")
+	assert.Contains(t, issueSvc.comments[42][0], "@bob")
 }
 
 func TestConsolidate_ConflictDispatchResolver(t *testing.T) {
@@ -632,6 +669,9 @@ func TestConsolidate_ConflictDispatchResolver(t *testing.T) {
 	assert.Len(t, createdIssues, 1)
 	assert.Contains(t, createdIssues[0].Title, "Resolve conflict")
 	assert.Len(t, wf.dispatched, 1)
+	// Original issue should be relabeled from done → failed to block tier advancement
+	assert.Contains(t, issueSvc.removedLabels[42], issues.StatusDone)
+	assert.Contains(t, issueSvc.addedLabels[42], issues.StatusFailed)
 }
 
 func TestConsolidate_ConflictMaxAttempts(t *testing.T) {
@@ -674,6 +714,48 @@ func TestConsolidate_ConflictMaxAttempts(t *testing.T) {
 	assert.Equal(t, 0, result.ConflictIssue) // No issue created
 	assert.Contains(t, issueSvc.comments[42][0], "max resolution attempts")
 	assert.Len(t, wf.dispatched, 0) // No dispatch
+	// Should relabel from done → failed to block tier advancement
+	assert.Contains(t, issueSvc.removedLabels[42], issues.StatusDone)
+	assert.Contains(t, issueSvc.addedLabels[42], issues.StatusFailed)
+}
+
+func TestConsolidate_ConflictMaxAttempts_MentionsUsers(t *testing.T) {
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = &platform.Issue{
+		Number: 42, Title: "Test",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+	issueSvc.listResult = []*platform.Issue{
+		{Number: 80, Body: "---\nherd:\n  version: 1\n  conflict_resolution: true\n---\n\n## Task\nResolve\n"},
+		{Number: 81, Body: "---\nherd:\n  version: 1\n  conflict_resolution: true\n---\n\n## Task\nResolve\n"},
+	}
+
+	wf := &mockWorkflowService{
+		runs: map[int64]*platform.Run{
+			100: {ID: 100, Conclusion: "success", Inputs: map[string]string{"issue_number": "42"}},
+		},
+	}
+
+	_, g := initConflictRepo(t)
+
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		workflows: wf,
+		repo: &mockRepoService{
+			defaultBranch: "main",
+			branchExists:  map[string]bool{"herd/worker/42-test": true},
+		},
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{OnConflict: "dispatch-resolver", MaxConflictResolutionAttempts: 2},
+		Monitor:    config.Monitor{NotifyUsers: []string{"alice"}},
+	}
+
+	_, err := Consolidate(context.Background(), mock, g, cfg, ConsolidateParams{RunID: 100})
+	require.NoError(t, err)
+	assert.Contains(t, issueSvc.comments[42][0], "@alice")
 }
 
 func TestAdvance_AllComplete_RebaseFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- Relabel issue done → failed when consolidation fails (blocks tier advancement)
- @mention `notify_users` in conflict notification comments
- Default `on_conflict` changed from `notify` to `dispatch-resolver`

## Problem
Worker marked itself done after pushing, but integrator failed to consolidate due to merge conflict. Tier advanced anyway because all issues showed done.

## Test plan
- [x] `TestConsolidate_ConflictNotify` — verifies done → failed relabeling
- [x] `TestConsolidate_ConflictNotify_MentionsUsers` — verifies @mentions
- [x] `TestConsolidate_ConflictDispatchResolver` — verifies done → failed relabeling
- [x] `TestConsolidate_ConflictMaxAttempts` — verifies done → failed relabeling
- [x] `TestConsolidate_ConflictMaxAttempts_MentionsUsers` — verifies @mentions
- [x] `TestDefault` — updated for new default
- [x] All tests pass