### PR TITLE
Fix review diff failure on batch branch

### DIFF
--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -110,14 +110,19 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 		return &ReviewResult{Approved: true, BatchPRNumber: pr.Number}, nil
 	}
 
-	// Get diff
+	// Fetch remote refs so the batch branch is available locally
+	_ = g.Fetch("origin") // best-effort — may fail in test environments without a remote
 	defaultBranch, err := p.Repository().GetDefaultBranch(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting default branch: %w", err)
 	}
-	diff, err := g.Diff(defaultBranch, batchBranch)
+	// Try remote refs first (Actions checkout), fall back to local refs (tests)
+	diff, err := g.Diff("origin/"+defaultBranch, "origin/"+batchBranch)
 	if err != nil {
-		return nil, fmt.Errorf("getting diff: %w", err)
+		diff, err = g.Diff(defaultBranch, batchBranch)
+		if err != nil {
+			return nil, fmt.Errorf("getting diff: %w", err)
+		}
 	}
 
 	// Collect acceptance criteria from all milestone issues


### PR DESCRIPTION
## Summary
- Fetch origin before diffing in review to ensure batch branch refs are available
- Try remote refs first (origin/main...origin/herd/batch/...), fall back to local refs for tests

## Problem
`git diff main...herd/batch/9-comment-command-system` failed because the Actions checkout only fetched main, not the batch branch.

## Test plan
- [x] All existing review tests pass (use local ref fallback)
- [ ] Verify in production that review can diff the batch branch