### PR TITLE
Fix Dockerfile.herd_runner permission error

### DIFF
--- a/Dockerfile.herd_runner
+++ b/Dockerfile.herd_runner
@@ -3,8 +3,12 @@
 
 FROM herd-runner-base
 
+USER root
+
 # Go toolchain (needed for building, testing, and linting)
 RUN apt-get update && apt-get install -y golang-go && rm -rf /var/lib/apt/lists/*
 
 # golangci-lint
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+
+USER runner

--- a/internal/cli/runner/Dockerfile.herd_runner.tmpl
+++ b/internal/cli/runner/Dockerfile.herd_runner.tmpl
@@ -7,6 +7,10 @@
 
 FROM herd-runner-base
 
+# The base image runs as the 'runner' user. Switch to root to install
+# packages, then switch back when done.
+USER root
+
 # Examples — uncomment what your project needs:
 #
 # Go
@@ -17,3 +21,5 @@ FROM herd-runner-base
 #
 # Rust
 # RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+USER runner


### PR DESCRIPTION
## Summary
- Add `USER root` before package installs, `USER runner` after
- Updated both repo Dockerfile and embedded template

## Problem
`apt-get update` failed with permission denied because the base image's `USER runner` is inherited.

## Test plan
- [x] All tests pass
- [ ] `docker compose -f docker-compose.herd.yml build` succeeds