### PR TITLE
Fix docker-compose base service running entrypoint

### DIFF
--- a/docker-compose.herd.yml
+++ b/docker-compose.herd.yml
@@ -1,15 +1,18 @@
 # HerdOS runner configuration
 # 1. Copy .env.herd.example to .env and fill in your tokens
 # 2. Customize Dockerfile.herd_runner with project-specific tools
-# 3. Start runners: docker compose -f docker-compose.herd.yml up -d
-# 4. Scale:         docker compose -f docker-compose.herd.yml up -d --scale worker=5
-# 5. Stop:          docker compose -f docker-compose.herd.yml down
+# 3. Build:  docker compose -f docker-compose.herd.yml build
+# 4. Start:  docker compose -f docker-compose.herd.yml up -d
+# 5. Scale:  docker compose -f docker-compose.herd.yml up -d --scale worker=5
+# 6. Stop:   docker compose -f docker-compose.herd.yml down
 
 services:
   herd-runner-base:
     build:
       dockerfile: Dockerfile.herd_runner_base
     image: herd-runner-base
+    entrypoint: ["true"]
+    restart: "no"
   worker:
     build:
       dockerfile: Dockerfile.herd_runner

--- a/internal/cli/runner/docker-compose.herd.yml.tmpl
+++ b/internal/cli/runner/docker-compose.herd.yml.tmpl
@@ -1,15 +1,18 @@
 # HerdOS runner configuration
 # 1. Copy .env.herd.example to .env and fill in your tokens
 # 2. Customize Dockerfile.herd_runner with project-specific tools
-# 3. Start runners: docker compose -f docker-compose.herd.yml up -d
-# 4. Scale:         docker compose -f docker-compose.herd.yml up -d --scale worker=5
-# 5. Stop:          docker compose -f docker-compose.herd.yml down
+# 3. Build:  docker compose -f docker-compose.herd.yml build
+# 4. Start:  docker compose -f docker-compose.herd.yml up -d
+# 5. Scale:  docker compose -f docker-compose.herd.yml up -d --scale worker=5
+# 6. Stop:   docker compose -f docker-compose.herd.yml down
 
 services:
   herd-runner-base:
     build:
       dockerfile: Dockerfile.herd_runner_base
     image: herd-runner-base
+    entrypoint: ["true"]
+    restart: "no"
   worker:
     build:
       dockerfile: Dockerfile.herd_runner


### PR DESCRIPTION
## Summary
- Override base service entrypoint with `["true"]` so it exits immediately
- Set `restart: "no"` on base service
- Updated both repo file and embedded template

## Problem
`docker compose up` tried to run the base image as a container, which failed because the entrypoint expects `REPO_URL` and other runner env vars.

## Test plan
- [x] All tests pass
- [ ] `docker compose -f docker-compose.herd.yml up` works