### PR TITLE
Support 0 = unlimited for fix cycle caps

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -17,8 +17,8 @@ integrator:
     max_conflict_resolution_attempts: 2
     require_ci: true
     review: true
-    review_max_fix_cycles: 10
-    ci_max_fix_cycles: 10
+    review_max_fix_cycles: 0
+    ci_max_fix_cycles: 0
 monitor:
     patrol_interval_minutes: 15
     stale_threshold_minutes: 30

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -147,7 +147,7 @@ func TestValidateErrors(t *testing.T) {
 		{"negative timeout", func(c *Config) { c.Workers.TimeoutMinutes = -1 }, "workers.timeout_minutes must be > 0"},
 		{"bad strategy", func(c *Config) { c.Integrator.Strategy = "yolo" }, "integrator.strategy must be one of"},
 		{"bad on_conflict", func(c *Config) { c.Integrator.OnConflict = "panic" }, "integrator.on_conflict must be one of"},
-		{"zero fix cycles", func(c *Config) { c.Integrator.ReviewMaxFixCycles = 0 }, "integrator.review_max_fix_cycles must be > 0"},
+		{"negative fix cycles", func(c *Config) { c.Integrator.ReviewMaxFixCycles = -1 }, "integrator.review_max_fix_cycles must be >= 0"},
 		{"negative ci cycles", func(c *Config) { c.Integrator.CIMaxFixCycles = -1 }, "integrator.ci_max_fix_cycles must be >= 0"},
 		{"low patrol", func(c *Config) { c.Monitor.PatrolIntervalMinutes = 3 }, "monitor.patrol_interval_minutes must be >= 5"},
 		{"zero stale", func(c *Config) { c.Monitor.StaleThresholdMinutes = 0 }, "monitor.stale_threshold_minutes must be > 0"},

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -60,11 +60,11 @@ func Validate(cfg *Config) *ValidationError {
 	if cfg.Integrator.MaxConflictResolutionAttempts <= 0 {
 		ve.Errors = append(ve.Errors, fmt.Sprintf("integrator.max_conflict_resolution_attempts must be > 0, got %d", cfg.Integrator.MaxConflictResolutionAttempts))
 	}
-	if cfg.Integrator.ReviewMaxFixCycles <= 0 {
-		ve.Errors = append(ve.Errors, fmt.Sprintf("integrator.review_max_fix_cycles must be > 0, got %d", cfg.Integrator.ReviewMaxFixCycles))
+	if cfg.Integrator.ReviewMaxFixCycles < 0 {
+		ve.Errors = append(ve.Errors, fmt.Sprintf("integrator.review_max_fix_cycles must be >= 0 (0 = unlimited), got %d", cfg.Integrator.ReviewMaxFixCycles))
 	}
 	if cfg.Integrator.CIMaxFixCycles < 0 {
-		ve.Errors = append(ve.Errors, fmt.Sprintf("integrator.ci_max_fix_cycles must be >= 0, got %d", cfg.Integrator.CIMaxFixCycles))
+		ve.Errors = append(ve.Errors, fmt.Sprintf("integrator.ci_max_fix_cycles must be >= 0 (0 = unlimited), got %d", cfg.Integrator.CIMaxFixCycles))
 	}
 
 	// Monitor

--- a/internal/integrator/ci.go
+++ b/internal/integrator/ci.go
@@ -110,14 +110,8 @@ func CheckCI(ctx context.Context, p platform.Platform, cfg *config.Config, param
 		}
 	}
 
-	// Check caps
-	if cfg.Integrator.CIMaxFixCycles == 0 {
-		// Notify-only mode
-		notifyCI(ctx, p, batchBranch, "CI failed. `ci_max_fix_cycles` is 0 — no fix workers will be dispatched.")
-		return &CheckCIResult{Status: "failure", MaxCyclesHit: true}, nil
-	}
-
-	if currentCycle >= cfg.Integrator.CIMaxFixCycles {
+	// Check caps (0 = unlimited)
+	if cfg.Integrator.CIMaxFixCycles > 0 && currentCycle >= cfg.Integrator.CIMaxFixCycles {
 		notifyCI(ctx, p, batchBranch, fmt.Sprintf(
 			"CI failed but max fix cycles (%d) reached. Manual intervention needed.", cfg.Integrator.CIMaxFixCycles))
 		return &CheckCIResult{Status: "failure", MaxCyclesHit: true}, nil

--- a/internal/integrator/ci_test.go
+++ b/internal/integrator/ci_test.go
@@ -120,13 +120,13 @@ func TestCheckCI(t *testing.T) {
 			expectMaxHit: true,
 		},
 		{
-			name:         "failure — re-run fails, zero cycles (notify only)",
-			ciStatus:     "failure",
-			rerunErr:     fmt.Errorf("re-run failed"),
-			requireCI:    true,
-			ciMaxCycles:  0,
-			expectStatus: "failure",
-			expectMaxHit: true,
+			name:           "failure — re-run fails, zero cycles (unlimited)",
+			ciStatus:       "failure",
+			rerunErr:       fmt.Errorf("re-run failed"),
+			requireCI:      true,
+			ciMaxCycles:    0,
+			expectStatus:   "failure",
+			expectFixCount: 1,
 		},
 	}
 

--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -194,7 +194,7 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 	// Handle changes requested — determine fix cycle
 	currentCycle := findMaxFixCycle(allIssues)
 
-	if currentCycle >= cfg.Integrator.ReviewMaxFixCycles {
+	if cfg.Integrator.ReviewMaxFixCycles > 0 && currentCycle >= cfg.Integrator.ReviewMaxFixCycles {
 		comment := fmt.Sprintf("⚠️ **HerdOS Integrator**\n\nAgent review found issues but max fix cycles (%d) reached. Manual intervention needed:\n\n",
 			cfg.Integrator.ReviewMaxFixCycles)
 		for _, c := range reviewResult.Comments {


### PR DESCRIPTION
## Summary
- 0 = unlimited cycles for both `review_max_fix_cycles` and `ci_max_fix_cycles`
- Default remains 10 for new projects
- Herd repo config set to 0 for debugging current batch
- Removed CI "notify-only" mode (0 previously meant no fix dispatch)
- Updated validation: >= 0 instead of > 0

## Test plan
- [x] CI test updated for 0 = unlimited behavior
- [x] Validation test updated
- [x] All tests pass