### PR TITLE
Force push worker branches to handle retries

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -162,8 +162,9 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 		return &ExecResult{NoOp: true}, nil
 	}
 
-	// Push worker branch
-	if err = g.Push("origin", workerBranch); err != nil {
+	// Force push worker branch — previous failed attempts may have left
+	// stale commits on the remote branch that would cause a non-fast-forward rejection.
+	if err = g.ForcePush("origin", workerBranch); err != nil {
 		return nil, fmt.Errorf("pushing worker branch: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Worker uses `ForcePush` instead of `Push` for worker branches
- Previous failed attempts leave stale commits that block retries

## Problem
Worker #180 failed 3+ times because the remote branch had commits from a previous attempt, causing non-fast-forward rejection on push.

## Test plan
- [x] All tests pass
- [ ] Retried workers can push successfully