### PR TITLE
Fix review argument list too long on large diffs

### DIFF
--- a/internal/agent/claude/review.go
+++ b/internal/agent/claude/review.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"text/template"
@@ -50,17 +52,20 @@ func (c *ClaudeAgent) Review(ctx context.Context, diff string, opts agent.Review
 		return nil, fmt.Errorf("rendering review prompt: %w", err)
 	}
 
-	args := []string{"-p", prompt, "--dangerously-skip-permissions", "--system-prompt", reviewSystemPrompt}
+	// Pass prompt via stdin to avoid "argument list too long" on large diffs.
+	args := []string{"--dangerously-skip-permissions", "--system-prompt", reviewSystemPrompt}
 	if c.Model != "" {
 		args = append(args, "--model", c.Model)
 	}
+	args = append(args, "-p")
 
 	cmd := exec.CommandContext(ctx, c.BinaryPath, args...)
 	cmd.Dir = opts.RepoRoot
+	cmd.Stdin = strings.NewReader(prompt)
 
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("agent review exited with error: %w\n%s", err, stderr.String())

--- a/internal/agent/claude/review_test.go
+++ b/internal/agent/claude/review_test.go
@@ -1,6 +1,9 @@
 package claude
 
 import (
+	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/herd-os/herd/internal/agent"
@@ -99,4 +102,48 @@ func TestRenderReviewPrompt_NoRoleInstructions(t *testing.T) {
 	prompt, err := renderReviewPrompt("diff", opts)
 	require.NoError(t, err)
 	assert.NotContains(t, prompt, "Project-Specific Review Instructions")
+}
+
+func TestReview_LargeDiffPassedViaStdin(t *testing.T) {
+	// Verify the review passes the prompt via stdin (not CLI args)
+	// by checking that a large prompt doesn't cause "argument list too long"
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	// Script reads stdin and outputs approved JSON
+	err := os.WriteFile(script, []byte(`#!/bin/sh
+cat > /dev/null
+echo '{"approved": true, "comments": [], "summary": "LGTM"}'
+`), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+
+	// Create a large diff (200KB)
+	largeDiff := strings.Repeat("+ some added line\n", 12000)
+
+	result, err := a.Review(context.Background(), largeDiff, agent.ReviewOptions{
+		AcceptanceCriteria: []string{"tests pass"},
+		RepoRoot:           dir,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Approved)
+}
+
+func TestReview_StreamsOutputToStdout(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte(`#!/bin/sh
+cat > /dev/null
+echo '{"approved": false, "comments": ["issue found"], "summary": "needs work"}'
+`), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	result, err := a.Review(context.Background(), "small diff", agent.ReviewOptions{
+		AcceptanceCriteria: []string{"works"},
+		RepoRoot:           dir,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Approved)
+	assert.Len(t, result.Comments, 1)
 }


### PR DESCRIPTION
## Summary
- Review prompt passed via stdin instead of CLI argument
- Streams output to stdout via MultiWriter (same as worker)
- Adds test with 200KB diff to verify no argument size limit

## Problem
`fork/exec: argument list too long` when reviewing batches with large accumulated diffs.

## Test plan
- [x] `TestReview_LargeDiffPassedViaStdin` — 200KB diff passes without error
- [x] `TestReview_StreamsOutputToStdout` — output captured correctly
- [x] All tests pass