### PR TITLE
Set agent model to Opus

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -6,7 +6,7 @@ platform:
 agent:
     provider: claude
     binary: ""
-    model: ""
+    model: "opus"
 workers:
     max_concurrent: 3
     runner_label: herd-worker


### PR DESCRIPTION
Workers and reviewer will use Opus instead of defaulting to Sonnet.