### PR TITLE
Use PR diff for review instead of git diff

### DIFF
--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -92,6 +92,8 @@ type mockPRService struct {
 	getResult  map[int]*platform.PullRequest
 	created    *platform.PullRequest
 	merged     bool
+	diffResult string
+	comments   map[int][]string
 }
 
 func (m *mockPRService) Create(_ context.Context, title, body, head, base string) (*platform.PullRequest, error) {
@@ -117,7 +119,19 @@ func (m *mockPRService) Merge(_ context.Context, _ int, _ platform.MergeMethod) 
 	return &platform.MergeResult{Merged: true}, nil
 }
 func (m *mockPRService) UpdateBranch(_ context.Context, _ int) error { return nil }
-func (m *mockPRService) AddComment(_ context.Context, _ int, _ string) error { return nil }
+func (m *mockPRService) AddComment(_ context.Context, number int, body string) error {
+	if m.comments == nil {
+		m.comments = map[int][]string{}
+	}
+	m.comments[number] = append(m.comments[number], body)
+	return nil
+}
+func (m *mockPRService) GetDiff(_ context.Context, _ int) (string, error) {
+	if m.diffResult != "" {
+		return m.diffResult, nil
+	}
+	return "diff --git a/file.go b/file.go\n", nil
+}
 func (m *mockPRService) CreateReview(_ context.Context, _ int, _ string, _ platform.ReviewEvent) error {
 	return nil
 }

--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -110,19 +110,13 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 		return &ReviewResult{Approved: true, BatchPRNumber: pr.Number}, nil
 	}
 
-	// Fetch remote refs so the batch branch is available locally
-	_ = g.Fetch("origin") // best-effort — may fail in test environments without a remote
-	defaultBranch, err := p.Repository().GetDefaultBranch(ctx)
+	// Use the PR diff from GitHub API — this shows exactly what will be
+	// merged, excluding commits already on main. Using git diff was unreliable
+	// because merging main into the batch branch caused the reviewer to see
+	// changes that were already on main.
+	diff, err := p.PullRequests().GetDiff(ctx, pr.Number)
 	if err != nil {
-		return nil, fmt.Errorf("getting default branch: %w", err)
-	}
-	// Try remote refs first (Actions checkout), fall back to local refs (tests)
-	diff, err := g.Diff("origin/"+defaultBranch, "origin/"+batchBranch)
-	if err != nil {
-		diff, err = g.Diff(defaultBranch, batchBranch)
-		if err != nil {
-			return nil, fmt.Errorf("getting diff: %w", err)
-		}
+		return nil, fmt.Errorf("getting PR diff: %w", err)
 	}
 
 	// Collect acceptance criteria from all milestone issues

--- a/internal/monitor/patrol_test.go
+++ b/internal/monitor/patrol_test.go
@@ -130,6 +130,9 @@ func (m *mockPRService) AddComment(_ context.Context, number int, body string) e
 	m.comments[number] = append(m.comments[number], body)
 	return nil
 }
+func (m *mockPRService) GetDiff(_ context.Context, _ int) (string, error) {
+	return "", nil
+}
 
 type mockWorkflowService struct {
 	activeRuns    []*platform.Run

--- a/internal/orchestration_test.go
+++ b/internal/orchestration_test.go
@@ -233,6 +233,9 @@ func (s *statefulPRService) AddComment(_ context.Context, _ int, _ string) error
 func (s *statefulPRService) CreateReview(_ context.Context, _ int, _ string, _ platform.ReviewEvent) error {
 	return nil
 }
+func (s *statefulPRService) GetDiff(_ context.Context, _ int) (string, error) {
+	return "diff --git a/file.go b/file.go\n", nil
+}
 
 // --- Stateful Workflow Service ---
 

--- a/internal/platform/github/pullrequests.go
+++ b/internal/platform/github/pullrequests.go
@@ -132,6 +132,14 @@ func (s *pullRequestService) AddComment(ctx context.Context, number int, body st
 	return nil
 }
 
+func (s *pullRequestService) GetDiff(ctx context.Context, number int) (string, error) {
+	diff, _, err := s.c.gh.PullRequests.GetRaw(ctx, s.c.owner, s.c.repo, number, gh.RawOptions{Type: gh.Diff})
+	if err != nil {
+		return "", fmt.Errorf("getting diff for pull request #%d: %w", number, err)
+	}
+	return diff, nil
+}
+
 func mapPullRequest(pr *gh.PullRequest) *platform.PullRequest {
 	return &platform.PullRequest{
 		Number:    pr.GetNumber(),

--- a/internal/platform/github/pullrequests_test.go
+++ b/internal/platform/github/pullrequests_test.go
@@ -248,6 +248,21 @@ func TestPullRequestAddComment(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPullRequestGetDiff(t *testing.T) {
+	mux := http.NewServeMux()
+	// go-github's GetRaw sends Accept header for diff format
+	mux.HandleFunc("GET /repos/test-org/test-repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("diff --git a/file.go b/file.go\n+added line\n"))
+	})
+
+	client, _ := newTestClient(t, mux)
+	diff, err := client.PullRequests().GetDiff(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Contains(t, diff, "diff --git")
+	assert.Contains(t, diff, "+added line")
+}
+
 func TestMapPullRequest(t *testing.T) {
 	ts := gh.Timestamp{Time: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)}
 	pr := mapPullRequest(&gh.PullRequest{

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -37,6 +37,7 @@ type PullRequestService interface {
 	UpdateBranch(ctx context.Context, number int) error
 	CreateReview(ctx context.Context, number int, body string, event ReviewEvent) error
 	AddComment(ctx context.Context, number int, body string) error
+	GetDiff(ctx context.Context, number int) (string, error)
 }
 
 type WorkflowService interface {


### PR DESCRIPTION
## Summary
- Add `GetDiff(ctx, number)` to `PullRequestService` using GitHub's PR diff endpoint
- Review uses PR diff instead of `git diff main...batch-branch`
- No longer needs git fetch or local branch refs

## Problem
Reviewer was reviewing code already on main because merging main into the batch branch made the git diff include those changes.

## Test plan
- [x] `TestPullRequestGetDiff` — API returns diff correctly
- [x] All mocks updated with `GetDiff`
- [x] All tests pass