### PR TITLE
Fix runner restart loop on stale config

### DIFF
--- a/entrypoint.herd.sh
+++ b/entrypoint.herd.sh
@@ -39,7 +39,7 @@ REPO_NAME=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\2|')
 
 # Remove stale config from previous run (ephemeral runners leave config behind on restart)
 if [ -f .runner ]; then
-  ./config.sh remove --token "$(get_token)" || true
+  ./config.sh remove --token "$(get_token)" || rm -f .runner .credentials .credentials_rsaparams
 fi
 
 ./config.sh \

--- a/internal/cli/runner/entrypoint.herd.sh
+++ b/internal/cli/runner/entrypoint.herd.sh
@@ -39,7 +39,7 @@ REPO_NAME=$(echo "$REPO_URL" | sed -E 's|.*/([^/]+)/([^/]+)$|\2|')
 
 # Remove stale config from previous run (ephemeral runners leave config behind on restart)
 if [ -f .runner ]; then
-  ./config.sh remove --token "$(get_token)" || true
+  ./config.sh remove --token "$(get_token)" || rm -f .runner .credentials .credentials_rsaparams
 fi
 
 ./config.sh \


### PR DESCRIPTION
Force remove .runner config files when API deregistration fails due to runner still being marked active.