### PR TITLE
[herd] Agent error detection and resilience (4 tasks)

### DIFF
--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -484,7 +484,20 @@ Manual tasks participate fully in the DAG:
 
 ---
 
-## 10. Failure Modes
+## 10. Agent Error Resilience
+
+The claude agent package validates output from every agent invocation. When Claude Code exits with code 0 but returns suspicious output (empty, "Execution error", or very short single-line output under 20 characters), the system:
+
+1. **Retries once** after a 5-second delay
+2. If the retry also returns suspicious output, **returns an error** instead of treating it as a successful result
+3. The worker posts a **"Worker failed"** comment on the issue explaining what happened
+4. The deferred error handler labels the issue as `failed` and triggers the Monitor
+
+This prevents the system from marking issues as done when the agent didn't actually do any work (e.g., during API instability). The integrator also handles review agent failures gracefully -- if the review agent fails, the review cycle is skipped entirely (no approval, no fix issues) and will retry on the next trigger.
+
+---
+
+## 11. Failure Modes
 
 ### Worker Fails to Complete
 

--- a/internal/agent/claude/execute.go
+++ b/internal/agent/claude/execute.go
@@ -8,17 +8,46 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/herd-os/herd/internal/agent"
 )
 
+const (
+	// minValidOutputLen is the minimum stdout length for agent output to be
+	// considered valid. Shorter single-line output is treated as suspicious
+	// (e.g., "Execution error" from API failures).
+	minValidOutputLen = 20
+
+	// retryDelay is the wait time before retrying after suspicious output.
+	retryDelay = 5 * time.Second
+)
+
+// isSuspiciousOutput returns true if the agent's stdout looks like an error
+// rather than real work output. This catches cases where Claude's API returns
+// exit code 0 with just "Execution error" or similar short error messages.
+func isSuspiciousOutput(stdout string) bool {
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return true
+	}
+	if strings.EqualFold(trimmed, "Execution error") {
+		return true
+	}
+	// Short single-line output is suspicious — real agent work produces
+	// multi-line summaries or at least a substantive single line.
+	if len(trimmed) < minValidOutputLen && !strings.Contains(trimmed, "\n") {
+		return true
+	}
+	return false
+}
+
 // Execute runs the configured agent in headless mode to complete a task.
 // The task body is passed as the prompt (-p), and the system prompt provides
 // worker instructions. The agent commits as it works in the repo.
+// If the agent returns suspicious output (empty, "Execution error", or very
+// short), Execute retries once after a 5s delay before returning an error.
 func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts agent.ExecOptions) (*agent.ExecResult, error) {
-	// Build the prompt: system prompt wraps the task body, so we pass
-	// the full rendered prompt via -p. The task body may start with ---
-	// (YAML front matter) which some CLI parsers misinterpret as a flag.
 	prompt := task.Body
 	if opts.SystemPrompt != "" {
 		prompt = opts.SystemPrompt
@@ -31,25 +60,44 @@ func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts age
 	if opts.MaxTurns > 0 {
 		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
 	}
-	// Use -p (print mode) which reads the prompt from stdin, avoiding the
-	// issue body's YAML front matter (---) being misinterpreted as a CLI flag.
 	args = append(args, "-p")
 
-	cmd := exec.CommandContext(ctx, c.BinaryPath, args...)
-	cmd.Dir = opts.RepoRoot
-	cmd.Stdin = strings.NewReader(prompt)
+	runOnce := func() (string, string, error) {
+		cmd := exec.CommandContext(ctx, c.BinaryPath, args...)
+		cmd.Dir = opts.RepoRoot
+		cmd.Stdin = strings.NewReader(prompt)
 
-	// Stream to both stdout/stderr (visible in Docker logs and Actions logs)
-	// and capture in buffers for the summary comment.
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("agent exited with error: %w\n%s", err, stderr.String())
+		if err := cmd.Run(); err != nil {
+			return "", stderr.String(), fmt.Errorf("agent exited with error: %w\n%s", err, stderr.String())
+		}
+		return stdout.String(), stderr.String(), nil
+	}
+
+	stdout, stderr, err := runOnce()
+	if err != nil {
+		return nil, err
+	}
+
+	if isSuspiciousOutput(stdout) {
+		fmt.Printf("Agent returned suspicious output (len=%d), retrying in %s...\nstdout: %s\nstderr: %s\n",
+			len(strings.TrimSpace(stdout)), retryDelay, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+		time.Sleep(retryDelay)
+
+		stdout, stderr, err = runOnce()
+		if err != nil {
+			return nil, err
+		}
+		if isSuspiciousOutput(stdout) {
+			return nil, fmt.Errorf("agent returned suspicious output after retry: stdout=%q stderr=%q",
+				strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+		}
 	}
 
 	return &agent.ExecResult{
-		Summary: stdout.String(),
+		Summary: stdout,
 	}, nil
 }

--- a/internal/agent/claude/execute_test.go
+++ b/internal/agent/claude/execute_test.go
@@ -2,8 +2,10 @@ package claude
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/herd-os/herd/internal/agent"
@@ -103,8 +105,8 @@ func TestExecute_YAMLFrontmatterPrompt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			script := dir + "/test-agent.sh"
-			// Capture stdin verbatim to verify it arrives intact
-			err := os.WriteFile(script, []byte("#!/bin/sh\ncat"), 0755)
+			// Capture stdin verbatim with a prefix to avoid triggering suspicious output detection
+			err := os.WriteFile(script, []byte("#!/bin/sh\necho -n 'STDIN_CONTENT_RECEIVED:'\ncat"), 0755)
 			require.NoError(t, err)
 
 			a := New(script, "")
@@ -113,7 +115,7 @@ func TestExecute_YAMLFrontmatterPrompt(t *testing.T) {
 
 			result, err := a.Execute(context.Background(), task, opts)
 			require.NoError(t, err, "prompt starting with %q should not cause a CLI error", tt.body[:min(len(tt.body), 20)])
-			assert.Equal(t, tt.body, result.Summary, "prompt should arrive via stdin verbatim")
+			assert.Equal(t, "STDIN_CONTENT_RECEIVED:"+tt.body, result.Summary, "prompt should arrive via stdin verbatim")
 		})
 	}
 }
@@ -182,4 +184,83 @@ func TestExecute_CapturesOutput(t *testing.T) {
 	result, err := a.Execute(context.Background(), task, opts)
 	require.NoError(t, err)
 	assert.Contains(t, result.Summary, "task completed successfully")
+}
+
+func TestIsSuspiciousOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"empty string", "", true},
+		{"whitespace only", "   \n  ", true},
+		{"execution error", "Execution error", true},
+		{"execution error mixed case", "execution error", true},
+		{"execution error with whitespace", "  Execution error  \n", true},
+		{"short single line", "Error", true},
+		{"short no newline under threshold", "Something bad", true},
+		{"valid short with newline", "line1\nline2", false},
+		{"valid long output", "This is a real agent summary that describes work done on the task", false},
+		{"exactly at threshold single line", strings.Repeat("x", minValidOutputLen), false},
+		{"below threshold single line", strings.Repeat("x", minValidOutputLen-1), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSuspiciousOutput(tt.output))
+		})
+	}
+}
+
+func TestExecute_SuspiciousOutputReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\ncat > /dev/null\necho 'Execution error'"), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	task := agent.TaskSpec{Body: "do work"}
+	opts := agent.ExecOptions{RepoRoot: dir}
+
+	_, execErr := a.Execute(context.Background(), task, opts)
+	assert.Error(t, execErr)
+	assert.Contains(t, execErr.Error(), "suspicious output after retry")
+}
+
+func TestExecute_EmptyOutputReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\ncat > /dev/null"), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	task := agent.TaskSpec{Body: "do work"}
+	opts := agent.ExecOptions{RepoRoot: dir}
+
+	_, execErr := a.Execute(context.Background(), task, opts)
+	assert.Error(t, execErr)
+	assert.Contains(t, execErr.Error(), "suspicious output after retry")
+}
+
+func TestExecute_RetrySucceedsOnSecondAttempt(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	marker := dir + "/attempt"
+	err := os.WriteFile(script, []byte(fmt.Sprintf(`#!/bin/sh
+cat > /dev/null
+if [ -f "%s" ]; then
+  echo "Task completed successfully with detailed output"
+else
+  touch "%s"
+  echo "Execution error"
+fi
+`, marker, marker)), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	task := agent.TaskSpec{Body: "do work"}
+	opts := agent.ExecOptions{RepoRoot: dir}
+
+	result, execErr := a.Execute(context.Background(), task, opts)
+	require.NoError(t, execErr)
+	assert.Contains(t, result.Summary, "Task completed successfully")
 }

--- a/internal/agent/claude/review.go
+++ b/internal/agent/claude/review.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/herd-os/herd/internal/agent"
 )
@@ -69,24 +70,47 @@ func (c *ClaudeAgent) Review(ctx context.Context, diff string, opts agent.Review
 	}
 	args = append(args, "-p")
 
-	cmd := exec.CommandContext(ctx, c.BinaryPath, args...)
-	cmd.Dir = opts.RepoRoot
-	cmd.Stdin = strings.NewReader(prompt)
+	runOnce := func() (string, string, error) {
+		cmd := exec.CommandContext(ctx, c.BinaryPath, args...)
+		cmd.Dir = opts.RepoRoot
+		cmd.Stdin = strings.NewReader(prompt)
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("agent review exited with error: %w\n%s", err, stderr.String())
+		if err := cmd.Run(); err != nil {
+			return "", stderr.String(), fmt.Errorf("agent review exited with error: %w\n%s", err, stderr.String())
+		}
+		return stdout.String(), stderr.String(), nil
 	}
 
-	result, err := parseReviewOutput(stdout.String())
+	stdout, stderr, err := runOnce()
+	if err != nil {
+		return nil, err
+	}
+
+	if isSuspiciousOutput(stdout) {
+		fmt.Printf("Review agent returned suspicious output (len=%d), retrying in %s...\nstdout: %s\nstderr: %s\n",
+			len(strings.TrimSpace(stdout)), retryDelay, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+		time.Sleep(retryDelay)
+
+		stdout, stderr, err = runOnce()
+		if err != nil {
+			return nil, err
+		}
+		if isSuspiciousOutput(stdout) {
+			return nil, fmt.Errorf("review agent returned suspicious output after retry: stdout=%q stderr=%q",
+				strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+		}
+	}
+
+	result, err := parseReviewOutput(stdout)
 	if err != nil {
 		// If JSON parsing fails, treat as non-approved with raw output
 		return &agent.ReviewResult{
 			Approved: false,
-			Summary:  fmt.Sprintf("Failed to parse agent output as JSON: %s\nRaw output: %s", err, stdout.String()),
+			Summary:  fmt.Sprintf("Failed to parse agent output as JSON: %s\nRaw output: %s", err, stdout),
 		}, nil
 	}
 

--- a/internal/agent/claude/review_test.go
+++ b/internal/agent/claude/review_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -216,4 +217,58 @@ func TestRenderReviewPrompt_SeverityGuide(t *testing.T) {
 	assert.Contains(t, prompt, "HIGH: Bugs, security vulnerabilities")
 	assert.Contains(t, prompt, "MEDIUM: Missing edge cases")
 	assert.Contains(t, prompt, "LOW: Style preferences")
+}
+
+func TestReview_SuspiciousOutputReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\ncat > /dev/null\necho 'Execution error'"), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	_, reviewErr := a.Review(context.Background(), "diff", agent.ReviewOptions{
+		AcceptanceCriteria: []string{"works"},
+		RepoRoot:           dir,
+	})
+	assert.Error(t, reviewErr)
+	assert.Contains(t, reviewErr.Error(), "suspicious output after retry")
+}
+
+func TestReview_EmptyOutputReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\ncat > /dev/null"), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	_, reviewErr := a.Review(context.Background(), "diff", agent.ReviewOptions{
+		AcceptanceCriteria: []string{"works"},
+		RepoRoot:           dir,
+	})
+	assert.Error(t, reviewErr)
+	assert.Contains(t, reviewErr.Error(), "suspicious output after retry")
+}
+
+func TestReview_RetrySucceedsOnSecondAttempt(t *testing.T) {
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	marker := dir + "/attempt"
+	err := os.WriteFile(script, []byte(fmt.Sprintf(`#!/bin/sh
+cat > /dev/null
+if [ -f "%s" ]; then
+  echo '{"approved": true, "findings": [], "summary": "LGTM"}'
+else
+  touch "%s"
+  echo "Execution error"
+fi
+`, marker, marker)), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	result, reviewErr := a.Review(context.Background(), "diff", agent.ReviewOptions{
+		AcceptanceCriteria: []string{"works"},
+		RepoRoot:           dir,
+	})
+	require.NoError(t, reviewErr)
+	assert.True(t, result.Approved)
 }

--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -182,7 +182,18 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 
 	reviewResult, err := ag.Review(ctx, diff, reviewOpts)
 	if err != nil {
-		return nil, fmt.Errorf("agent review failed: %w", err)
+		// Agent failed (e.g., API error, suspicious output). Don't propagate the
+		// error — return a neutral result so the workflow succeeds and the review
+		// retries on the next trigger.
+		fmt.Printf("Review agent failed: %s. Will retry on next trigger.\n", err)
+		return &ReviewResult{BatchPRNumber: pr.Number}, nil
+	}
+
+	// Guard against failed review that returned a result instead of an error
+	// (backward compatibility with older claude package).
+	if strings.HasPrefix(reviewResult.Summary, "Failed to parse") {
+		fmt.Printf("Review agent returned unparseable output. Will retry on next trigger.\n")
+		return &ReviewResult{BatchPRNumber: pr.Number}, nil
 	}
 
 	// Partition findings by severity

--- a/internal/integrator/review_test.go
+++ b/internal/integrator/review_test.go
@@ -717,12 +717,15 @@ func TestReview_AgentError(t *testing.T) {
 	}
 
 	dir, g := initTestRepo(t)
-	_, err := Review(context.Background(), mock, ag, g, &config.Config{
+	result, err := Review(context.Background(), mock, ag, g, &config.Config{
 		Integrator: config.Integrator{Review: true, ReviewMaxFixCycles: 3},
 	}, ReviewParams{RunID: 100, RepoRoot: dir})
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "agent review failed")
+	// Agent errors now return a neutral result (not an error) so the workflow
+	// succeeds and the review retries on the next trigger.
+	require.NoError(t, err)
+	assert.False(t, result.Approved)
+	assert.Empty(t, result.FixIssues)
 }
 
 // mockCapturingPRService wraps mockPRService and captures AddComment and CreateReview calls.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -138,6 +138,9 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 
 	agentResult, err := ag.Execute(ctx, taskSpec, execOpts)
 	if err != nil {
+		_ = p.Issues().AddComment(ctx, params.IssueNumber,
+			fmt.Sprintf("**Worker failed:** agent returned an error.\n\n```\n%s\n```\n\nThis issue will be retried by the monitor.",
+				truncateOutput(err.Error(), 2000)))
 		return nil, fmt.Errorf("agent execution failed: %w", err)
 	}
 
@@ -174,6 +177,9 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 		}
 		retryResult, retryErr := ag.Execute(ctx, retrySpec, execOpts)
 		if retryErr != nil {
+			_ = p.Issues().AddComment(ctx, params.IssueNumber,
+				fmt.Sprintf("**Worker failed:** agent returned an error during validation retry.\n\n```\n%s\n```\n\nThis issue will be retried by the monitor.",
+					truncateOutput(retryErr.Error(), 2000)))
 			return nil, fmt.Errorf("agent retry after validation failure: %w", retryErr)
 		}
 		if retryResult != nil && retryResult.Summary != "" {


### PR DESCRIPTION
## Summary

Batch **Agent error detection and resilience** — 4 tasks across 3 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #287 | Update documentation for agent error detection and resilience | 2 | done |
| #286 | Integrator: handle review agent errors and failed-parse results gracefully | 1 | done |
| #285 | Worker: return error instead of marking done when agent fails | 1 | done |
| #284 | Add suspicious output detection and retry logic to claude agent package | 0 | done |

## Worker branches

- `herd/worker/287-update-documentation-for-agent-error-detection-and`
- `herd/worker/286-integrator-handle-review-agent-errors-and-failed-p`
- `herd/worker/285-worker-return-error-instead-of-marking-done-when-a`
- `herd/worker/284-add-suspicious-output-detection-and-retry-logic-to`
