### PR TITLE
Fix Node 22 for Claude Code + libicu for runner

### DIFF
--- a/Dockerfile.herd_runner_base
+++ b/Dockerfile.herd_runner_base
@@ -3,9 +3,11 @@ FROM ubuntu:24.04
 ARG RUNNER_VERSION=2.332.0
 ARG TARGETARCH
 
-# Dependencies
+# Dependencies (Node 22 LTS required by Claude Code, libicu for GitHub Actions runner)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl jq ca-certificates git gh nodejs npm \
+    curl jq ca-certificates git gh libicu-dev \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub Actions runner

--- a/internal/cli/runner/Dockerfile.herd_runner_base
+++ b/internal/cli/runner/Dockerfile.herd_runner_base
@@ -3,9 +3,11 @@ FROM ubuntu:24.04
 ARG RUNNER_VERSION=2.332.0
 ARG TARGETARCH
 
-# Dependencies
+# Dependencies (Node 22 LTS required by Claude Code, libicu for GitHub Actions runner)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl jq ca-certificates git gh nodejs npm \
+    curl jq ca-certificates git gh libicu-dev \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub Actions runner


### PR DESCRIPTION
Root cause of all Execution error failures — Node 18 too old for Claude Code 2.1.79.