### PR TITLE
Make agent debug logging opt-in via HERD_AGENT_DEBUG

### DIFF
--- a/docker-compose.herd.yml
+++ b/docker-compose.herd.yml
@@ -27,5 +27,6 @@ services:
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - HERD_VERSION=${HERD_VERSION:-}
+      - HERD_AGENT_DEBUG=${HERD_AGENT_DEBUG:-}
     deploy:
       replicas: 3

--- a/internal/agent/claude/execute.go
+++ b/internal/agent/claude/execute.go
@@ -54,8 +54,12 @@ func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts age
 		prompt = opts.SystemPrompt
 	}
 
-	debugFile := filepath.Join(opts.RepoRoot, "claude-debug.log")
-	args := []string{"--dangerously-skip-permissions", "--debug", "--debug-file", debugFile}
+	args := []string{"--dangerously-skip-permissions"}
+	debugFile := ""
+	if os.Getenv("HERD_AGENT_DEBUG") == "true" {
+		debugFile = filepath.Join(opts.RepoRoot, "claude-debug.log")
+		args = append(args, "--debug", "--debug-file", debugFile)
+	}
 	if c.Model != "" {
 		args = append(args, "--model", c.Model)
 	}
@@ -86,12 +90,16 @@ func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts age
 
 	if isSuspiciousOutput(stdout) {
 		// Dump debug log if available
-		if debugData, readErr := os.ReadFile(debugFile); readErr == nil && len(debugData) > 0 {
-			fmt.Printf("=== Claude debug log (attempt 1) ===\n%s\n=== End debug log ===\n", string(debugData))
+		if debugFile != "" {
+			if debugData, readErr := os.ReadFile(debugFile); readErr == nil && len(debugData) > 0 {
+				fmt.Printf("=== Claude debug log (attempt 1) ===\n%s\n=== End debug log ===\n", string(debugData))
+			}
 		}
 		fmt.Printf("Agent returned suspicious output (len=%d), retrying in %s...\nstdout: %s\nstderr: %s\n",
 			len(strings.TrimSpace(stdout)), retryDelay, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
-		_ = os.Remove(debugFile) // clear for retry
+		if debugFile != "" {
+			_ = os.Remove(debugFile) // clear for retry
+		}
 		time.Sleep(retryDelay)
 
 		stdout, stderr, err = runOnce()
@@ -100,8 +108,10 @@ func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts age
 		}
 		if isSuspiciousOutput(stdout) {
 			// Dump debug log for retry attempt
-			if debugData, readErr := os.ReadFile(debugFile); readErr == nil && len(debugData) > 0 {
-				fmt.Printf("=== Claude debug log (attempt 2) ===\n%s\n=== End debug log ===\n", string(debugData))
+			if debugFile != "" {
+				if debugData, readErr := os.ReadFile(debugFile); readErr == nil && len(debugData) > 0 {
+					fmt.Printf("=== Claude debug log (attempt 2) ===\n%s\n=== End debug log ===\n", string(debugData))
+				}
 			}
 			return nil, fmt.Errorf("agent returned suspicious output after retry: stdout=%q stderr=%q",
 				strings.TrimSpace(stdout), strings.TrimSpace(stderr))

--- a/internal/agent/claude/execute_test.go
+++ b/internal/agent/claude/execute_test.go
@@ -264,3 +264,41 @@ fi
 	require.NoError(t, execErr)
 	assert.Contains(t, result.Summary, "Task completed successfully")
 }
+
+func TestExecute_DebugModeDisabledByDefault(t *testing.T) {
+	// Ensure HERD_AGENT_DEBUG is not set
+	t.Setenv("HERD_AGENT_DEBUG", "")
+
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\ncat > /dev/null\necho \"$@\""), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	task := agent.TaskSpec{Body: "test"}
+	opts := agent.ExecOptions{RepoRoot: dir}
+
+	result, execErr := a.Execute(context.Background(), task, opts)
+	require.NoError(t, execErr)
+	// Should NOT contain --debug flag
+	assert.NotContains(t, result.Summary, "--debug")
+}
+
+func TestExecute_DebugModeEnabledByEnvVar(t *testing.T) {
+	t.Setenv("HERD_AGENT_DEBUG", "true")
+
+	dir := t.TempDir()
+	script := dir + "/test-agent.sh"
+	err := os.WriteFile(script, []byte("#!/bin/sh\ncat > /dev/null\necho \"$@\""), 0755)
+	require.NoError(t, err)
+
+	a := New(script, "")
+	task := agent.TaskSpec{Body: "test"}
+	opts := agent.ExecOptions{RepoRoot: dir}
+
+	result, execErr := a.Execute(context.Background(), task, opts)
+	require.NoError(t, execErr)
+	// Should contain --debug flag and --debug-file
+	assert.Contains(t, result.Summary, "--debug")
+	assert.Contains(t, result.Summary, "--debug-file")
+}

--- a/internal/cli/runner/.env.herd.example
+++ b/internal/cli/runner/.env.herd.example
@@ -18,3 +18,6 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Herd version for runner containers (optional — defaults to latest)
 # Set this to pin a specific version, e.g.:
 # HERD_VERSION=v0.1.0-rc.2
+
+# Enable agent debug logging (optional — dumps Claude Code debug logs on failure)
+# HERD_AGENT_DEBUG=true

--- a/internal/cli/runner/docker-compose.herd.yml.tmpl
+++ b/internal/cli/runner/docker-compose.herd.yml.tmpl
@@ -27,5 +27,6 @@ services:
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - HERD_VERSION=${HERD_VERSION:-}
+      - HERD_AGENT_DEBUG=${HERD_AGENT_DEBUG:-}
     deploy:
       replicas: 3


### PR DESCRIPTION
## Summary
- `HERD_AGENT_DEBUG=true` enables --debug and --debug-file on Claude Code
- Debug log dumped to stdout on suspicious output for Actions visibility
- Added to .env.herd.example, docker-compose template, and repo compose
- Tests verify debug flag present/absent based on env var

## Test plan
- [x] TestExecute_DebugModeDisabledByDefault
- [x] TestExecute_DebugModeEnabledByEnvVar
- [x] All tests pass