### PR TITLE
[herd] Fix docs: MEDIUM findings now trigger fix workers (1 tasks)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,10 +60,10 @@ Controls how aggressively the agent reviewer flags issues:
 
 Findings are classified by severity:
 - **HIGH**: Bugs, security vulnerabilities, race conditions, missing critical error handling — triggers fix workers
-- **MEDIUM**: Missing edge cases, suboptimal error handling — informational only
+- **MEDIUM**: Missing edge cases, suboptimal error handling — triggers fix workers
 - **LOW**: Style preferences, naming suggestions — informational only
 
-Only HIGH severity findings create fix issues and dispatch workers. MEDIUM and LOW findings are listed in the PR comment for reference.
+HIGH and MEDIUM severity findings create fix issues and dispatch workers. LOW findings are listed in the PR comment for reference.
 
 ## Managing Configuration
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -77,7 +77,7 @@ The entire flow after `herd plan` is self-driving. The Planner dispatches Tier 0
 
 ### Review and Fix Details
 
-Agent review collects `/herd fix` comments from the batch PR before reviewing, so user-requested fixes are not flagged as violations. It then classifies findings by severity (HIGH, MEDIUM, LOW). Only HIGH severity findings — bugs, security issues, race conditions — trigger fix workers. MEDIUM and LOW findings are included in the PR comment for reference but do not block merge or create fix issues.
+Agent review collects `/herd fix` comments from the batch PR before reviewing, so user-requested fixes are not flagged as violations. It then classifies findings by severity (HIGH, MEDIUM, LOW). HIGH and MEDIUM severity findings trigger fix workers. LOW findings are included in the PR comment for reference but do not block merge or create fix issues.
 
 Each review cycle creates at most one batch fix issue containing all HIGH findings, rather than one issue per finding. The agent submits a Request Changes review to block merge while fix cycles are active. When the review passes, the agent approves and posts a batch summary with statistics (files reviewed, findings by severity, fix cycles used).
 

--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -263,7 +263,7 @@ Review findings are classified by severity:
 | Severity | Examples | Action |
 |----------|----------|--------|
 | HIGH | Bugs, security vulnerabilities, race conditions, missing critical error handling | Creates fix issues, dispatches workers |
-| MEDIUM | Missing edge cases, suboptimal error handling | Listed in PR comment, no fix workers |
+| MEDIUM | Missing edge cases, suboptimal error handling | Creates fix issues, dispatches workers |
 | LOW | Style preferences, naming suggestions | Listed in PR comment, no fix workers |
 
 The `review_strictness` setting (standard/strict/lenient) controls which issues the agent flags. See [Configuration](../configuration.md#review-strictness) for details.


### PR DESCRIPTION
## Summary

Batch **Fix docs: MEDIUM findings now trigger fix workers** — 1 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #324 | Update all docs to reflect MEDIUM severity findings triggering fix workers | 0 | done |

## Worker branches

- `herd/worker/324-update-all-docs-to-reflect-medium-severity-finding`
