### PR TITLE
[herd] Handle missing CI gracefully and update PAT docs (2 tasks)

### DIFF
--- a/WORKER_PROGRESS.md
+++ b/WORKER_PROGRESS.md
@@ -1,7 +1,0 @@
-- [x] Update `internal/platform/github/checks.go` to handle 403/404 gracefully
-- [x] Add tests for 403, 404, and mixed scenarios in `checks_test.go`
-- [x] Verify `go build ./...` passes
-- [x] Verify `go test ./...` passes
-- [x] Verify `go vet ./...` passes
-- [ ] golangci-lint: skipped (no compatible version for Go 1.26.1)
-- [x] Commit and push changes

--- a/internal/platform/github/checks.go
+++ b/internal/platform/github/checks.go
@@ -20,12 +20,14 @@ func (s *checkService) GetCombinedStatus(ctx context.Context, ref string) (strin
 	// external apps like Cloudflare). The combined result is the worst of the two.
 
 	// 1. Commit statuses
+	var permissionDenied bool
 	commitStatus, _, err := s.c.gh.Repositories.GetCombinedStatus(ctx, s.c.owner, s.c.repo, ref, nil)
 	var statusState string
 	if err != nil {
 		var errResp *gh.ErrorResponse
 		if errors.As(err, &errResp) && (errResp.Response.StatusCode == 403 || errResp.Response.StatusCode == 404) {
 			statusState = ""
+			permissionDenied = true
 		} else {
 			return "", fmt.Errorf("getting combined status for %s: %w", ref, err)
 		}
@@ -40,6 +42,7 @@ func (s *checkService) GetCombinedStatus(ctx context.Context, ref string) (strin
 		var errResp *gh.ErrorResponse
 		if errors.As(err, &errResp) && (errResp.Response.StatusCode == 403 || errResp.Response.StatusCode == 404) {
 			checksState = ""
+			permissionDenied = true
 		} else {
 			return "", fmt.Errorf("listing check runs for %s: %w", ref, err)
 		}
@@ -60,9 +63,11 @@ func (s *checkService) GetCombinedStatus(ctx context.Context, ref string) (strin
 		}
 	}
 
-	// If both endpoints failed or returned nothing, treat as no CI available.
+	// If both endpoints returned nothing, treat as no CI available.
 	if statusState == "" && checksState == "" {
-		fmt.Fprintf(os.Stderr, "warning: CI status unavailable for %s (no CI configured or insufficient permissions), treating as success\n", ref)
+		if permissionDenied {
+			fmt.Fprintf(os.Stderr, "warning: CI status unavailable for %s (insufficient permissions), treating as success\n", ref)
+		}
 		return "success", nil
 	}
 

--- a/internal/platform/github/checks_test.go
+++ b/internal/platform/github/checks_test.go
@@ -195,6 +195,38 @@ func TestGetCombinedStatus_404ReturnsSuccess(t *testing.T) {
 	assert.Equal(t, "success", status)
 }
 
+func TestGetCombinedStatus_500OnStatusReturnsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Internal Server Error"})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{Total: gh.Ptr(0)})
+	})
+
+	client, _ := newTestClient(t, mux)
+	_, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting combined status for main")
+}
+
+func TestGetCombinedStatus_500OnCheckRunsReturnsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Internal Server Error"})
+	})
+
+	client, _ := newTestClient(t, mux)
+	_, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing check runs for main")
+}
+
 func TestGetCombinedStatus_403OnCheckRunsOnly(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

Batch **Handle missing CI gracefully and update PAT docs** — 2 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #378 | Add missing Statuses permission to PAT docs | 0 | done |
| #377 | Handle 403/404 gracefully in GetCombinedStatus | 0 | done |

## Worker branches

- `herd/worker/378-add-missing-statuses-permission-to-pat-docs`
- `herd/worker/377-handle-403404-gracefully-in-getcombinedstatus`
