### PR TITLE
[herd] Fix integrator consolidation: stale checkout and missing failure labeling (1 tasks)

### DIFF
--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -253,6 +253,15 @@ Given a completed workflow run ID, the Integrator resolves the worker branch:
    (no-op worker), skip merge. Either way, the issue counts toward tier
    completion.
 
+### Post-Merge Failure Handling
+
+If the merge succeeds but a downstream step fails (e.g., push rejected due to
+non-fast-forward), the Integrator relabels the issue from `herd/status:done` to
+`herd/status:failed` and posts a diagnostic comment. This ensures the issue is
+retried automatically rather than being treated as complete. The Integrator also
+resets the local batch branch to match the remote tracking branch before each
+checkout, preventing stale-branch issues.
+
 ### Branch Cleanup
 
 **Worker branches** are deleted after successful consolidation. Failed worker

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -39,6 +39,12 @@ func (g *Git) Checkout(branch string) error {
 	return g.run("checkout", branch)
 }
 
+// CheckoutReset checks out a branch, resetting it to match the remote tracking branch.
+// This ensures the local branch is up-to-date even if the remote has advanced.
+func (g *Git) CheckoutReset(branch string) error {
+	return g.run("checkout", "-B", branch, "origin/"+branch)
+}
+
 func (g *Git) CreateBranch(name, from string) error {
 	return g.run("checkout", "-b", name, from)
 }

--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -128,7 +128,7 @@ func Consolidate(ctx context.Context, p platform.Platform, g *git.Git, cfg *conf
 	if err := g.Fetch("origin"); err != nil {
 		return nil, fmt.Errorf("fetching: %w", err)
 	}
-	if err := g.Checkout(batchBranch); err != nil {
+	if err := g.CheckoutReset(batchBranch); err != nil {
 		return nil, fmt.Errorf("checking out batch branch: %w", err)
 	}
 	if err := g.Merge("origin/" + workerBranch); err != nil {
@@ -189,6 +189,12 @@ func Consolidate(ctx context.Context, p platform.Platform, g *git.Git, cfg *conf
 	}
 
 	if err := g.Push("origin", batchBranch); err != nil {
+		// Merge succeeded but push failed — relabel so the issue gets retried
+		_ = p.Issues().RemoveLabels(ctx, issueNumber, []string{issues.StatusDone})
+		_ = p.Issues().AddLabels(ctx, issueNumber, []string{issues.StatusFailed})
+		_ = p.Issues().AddComment(ctx, issueNumber, fmt.Sprintf(
+			"⚠️ **HerdOS Integrator**\n\nCould not push consolidated batch branch `%s` (non-fast-forward). This issue will be retried.\n\nYou can also retry with `/herd integrate` on this issue.",
+			batchBranch))
 		return nil, fmt.Errorf("pushing batch branch: %w", err)
 	}
 

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -1671,6 +1671,160 @@ func TestConsolidate_RmErrorsAreLogged(t *testing.T) {
 		"Rm errors for legacy file should be logged as warnings")
 }
 
+func initPushFailRepo(t *testing.T) (string, *git.Git) {
+	t.Helper()
+
+	// Create bare repo as "origin"
+	bareDir := t.TempDir()
+	runGit(t, "", "init", "--bare", "-b", "main", bareDir)
+
+	// Clone to working dir
+	dir := t.TempDir()
+	runGit(t, "", "clone", bareDir, dir)
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	// Initial commit
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "push", "origin", "main")
+
+	// Create batch branch and push
+	runGit(t, dir, "checkout", "-b", "herd/batch/1-batch")
+	runGit(t, dir, "push", "origin", "herd/batch/1-batch")
+
+	// Create worker branch with non-conflicting change and push
+	runGit(t, dir, "checkout", "-b", "herd/worker/42-test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "worker.txt"), []byte("worker content"), 0644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "worker change")
+	runGit(t, dir, "push", "origin", "herd/worker/42-test")
+
+	// Install a pre-receive hook on the bare repo that rejects pushes to the batch branch.
+	// This simulates a non-fast-forward rejection after the merge succeeds locally.
+	hookDir := filepath.Join(bareDir, "hooks")
+	hookPath := filepath.Join(hookDir, "pre-receive")
+	hookScript := "#!/bin/sh\nwhile read old new ref; do\n  case \"$ref\" in\n    refs/heads/herd/batch/*) exit 1;;\n  esac\ndone\n"
+	require.NoError(t, os.WriteFile(hookPath, []byte(hookScript), 0755))
+
+	// Back in first clone, checkout batch branch
+	runGit(t, dir, "checkout", "herd/batch/1-batch")
+
+	return dir, git.New(dir)
+}
+
+func initStaleCheckoutRepo(t *testing.T) (string, *git.Git) {
+	t.Helper()
+
+	// Create bare repo as "origin"
+	bareDir := t.TempDir()
+	runGit(t, "", "init", "--bare", "-b", "main", bareDir)
+
+	// Clone to working dir
+	dir := t.TempDir()
+	runGit(t, "", "clone", bareDir, dir)
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	// Initial commit
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "push", "origin", "main")
+
+	// Create batch branch and push
+	runGit(t, dir, "checkout", "-b", "herd/batch/1-batch")
+	runGit(t, dir, "push", "origin", "herd/batch/1-batch")
+
+	// Create worker branch with non-conflicting change and push
+	runGit(t, dir, "checkout", "-b", "herd/worker/42-test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "worker.txt"), []byte("worker content"), 0644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "worker change")
+	runGit(t, dir, "push", "origin", "herd/worker/42-test")
+
+	// Advance remote batch branch from a second clone
+	dir2 := t.TempDir()
+	runGit(t, "", "clone", bareDir, dir2)
+	runGit(t, dir2, "config", "user.email", "test@test.com")
+	runGit(t, dir2, "config", "user.name", "Test")
+	runGit(t, dir2, "checkout", "herd/batch/1-batch")
+	require.NoError(t, os.WriteFile(filepath.Join(dir2, "other.txt"), []byte("other content"), 0644))
+	runGit(t, dir2, "add", ".")
+	runGit(t, dir2, "commit", "-m", "advance remote batch")
+	runGit(t, dir2, "push", "origin", "herd/batch/1-batch")
+
+	// Back in first clone, checkout batch branch (now stale/behind remote)
+	runGit(t, dir, "checkout", "herd/batch/1-batch")
+
+	return dir, git.New(dir)
+}
+
+func TestConsolidate_PushFailure_LabelsIssueFailed(t *testing.T) {
+	dir, g := initPushFailRepo(t)
+
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = &platform.Issue{
+		Number: 42, Title: "Test",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	mock := &mockPlatform{
+		issues: issueSvc,
+		workflows: &mockWorkflowService{
+			runs: map[int64]*platform.Run{
+				100: {ID: 100, Conclusion: "success", Inputs: map[string]string{"issue_number": "42"}},
+			},
+		},
+		repo: &mockRepoService{
+			defaultBranch: "main",
+			branchExists:  map[string]bool{"herd/worker/42-test": true},
+		},
+	}
+
+	_, err := Consolidate(context.Background(), mock, g, &config.Config{}, ConsolidateParams{RunID: 100, RepoRoot: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pushing batch branch")
+
+	// Verify relabeling
+	assert.Contains(t, issueSvc.removedLabels[42], issues.StatusDone)
+	assert.Contains(t, issueSvc.addedLabels[42], issues.StatusFailed)
+
+	// Verify comment
+	require.Len(t, issueSvc.comments[42], 1)
+	assert.Contains(t, issueSvc.comments[42][0], "Could not push consolidated batch branch")
+}
+
+func TestConsolidate_CheckoutTracksRemote(t *testing.T) {
+	dir, g := initStaleCheckoutRepo(t)
+
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = &platform.Issue{
+		Number: 42, Title: "Test",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	mock := &mockPlatform{
+		issues: issueSvc,
+		workflows: &mockWorkflowService{
+			runs: map[int64]*platform.Run{
+				100: {ID: 100, Conclusion: "success", Inputs: map[string]string{"issue_number": "42"}},
+			},
+		},
+		repo: &mockRepoService{
+			defaultBranch: "main",
+			branchExists:  map[string]bool{"herd/worker/42-test": true},
+		},
+	}
+
+	result, err := Consolidate(context.Background(), mock, g, &config.Config{}, ConsolidateParams{RunID: 100, RepoRoot: dir})
+	require.NoError(t, err)
+	assert.True(t, result.Merged)
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
## Summary

Batch **Fix integrator consolidation: stale checkout and missing failure labeling** — 1 tasks across 1 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #393 | Fix stale batch branch checkout and add post-merge failure labeling | 0 | done |

## Worker branches

- `herd/worker/393-fix-stale-batch-branch-checkout-and-add-post-merge`
