### PR TITLE
Document PR review blocking in GitHub App roadmap

### DIFF
--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -25,7 +25,7 @@ A user can:
 
 - **@herd-os mentions** -- users mention @herd-os in comments with natural language requests (e.g., "@herd-os the CI is broken, I think the Node version file is missing"). An agent interprets the request and calls the same command functions from `internal/commands/` as tool calls.
 - **Webhook-based handling** -- replace the `issue_comment` workflow trigger with a webhook endpoint on the GitHub App. Eliminates runner spin-up latency for command handling.
-- **Dedicated bot identity** -- all HerdOS comments, reactions, and reviews come from the `herd-os[bot]` account instead of the GITHUB_TOKEN identity.
+- **Dedicated bot identity** -- all HerdOS comments, reactions, and reviews come from the `herd-os[bot]` account instead of the GITHUB_TOKEN identity. This also fixes the PR review blocking issue: currently the PAT that creates batch PRs cannot submit "Changes Requested" reviews on them (GitHub prevents users from reviewing their own PRs). The GitHub App has a separate identity and can both create and review PRs, enabling the merge button to be blocked during active fix cycles.
 - **Issue-driven planning** -- users create an issue describing a feature, mention @herd-os, and the agent decomposes and dispatches without the CLI. Multi-turn conversation in the issue thread refines the plan.
 
 ### Multi-Agent


### PR DESCRIPTION
Notes that the GitHub App solves the PAT-can't-review-own-PRs limitation.