### PR TITLE
Bump GitHub Actions runner to 2.333.1

### DIFF
--- a/Dockerfile.herd_runner_base
+++ b/Dockerfile.herd_runner_base
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_VERSION=2.333.1
 ARG TARGETARCH
 
 # Dependencies (Node 22 LTS required by Claude Code, libicu for GitHub Actions runner)

--- a/internal/cli/runner/Dockerfile.herd_runner_base
+++ b/internal/cli/runner/Dockerfile.herd_runner_base
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_VERSION=2.333.1
 ARG TARGETARCH
 
 # Dependencies (Node 22 LTS required by Claude Code, libicu for GitHub Actions runner)


### PR DESCRIPTION
Runner 2.332.0 binaries appear corrupted or incompatible. Update to latest 2.333.1.