### PR TITLE
Fix cleanup not running when batch PR is closed without merging

### DIFF
--- a/.github/workflows/herd-integrator.yml
+++ b/.github/workflows/herd-integrator.yml
@@ -140,7 +140,6 @@ jobs:
       vars.HERD_ENABLED == 'true'
       && github.event_name == 'pull_request'
       && github.event.action == 'closed'
-      && github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.title, '[herd]')
     runs-on: [self-hosted, '${{ vars.HERD_RUNNER_LABEL || ''herd-worker'' }}']
     steps:
@@ -149,13 +148,18 @@ jobs:
         with:
           token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Post-merge cleanup
+      - name: Post-close cleanup
         env:
           HERD_RUNNER: "true"
           GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          herd integrator cleanup --pr "$PR_NUMBER"
+          MERGED_FLAG=""
+          if [ "$PR_MERGED" = "true" ]; then
+            MERGED_FLAG="--merged"
+          fi
+          herd integrator cleanup --pr "$PR_NUMBER" $MERGED_FLAG
 
   handle-comment:
     if: >

--- a/internal/cli/workflows/herd-integrator.yml
+++ b/internal/cli/workflows/herd-integrator.yml
@@ -152,7 +152,6 @@ jobs:
       vars.HERD_ENABLED == 'true'
       && github.event_name == 'pull_request'
       && github.event.action == 'closed'
-      && github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.title, '[herd]')
     concurrency:
       group: herd-cleanup-${{ github.event.pull_request.number }}
@@ -164,13 +163,18 @@ jobs:
         with:
           token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Post-merge cleanup
+      - name: Post-close cleanup
         env:
           HERD_RUNNER: "true"
           GITHUB_TOKEN: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          herd integrator cleanup --pr "$PR_NUMBER"
+          MERGED_FLAG=""
+          if [ "$PR_MERGED" = "true" ]; then
+            MERGED_FLAG="--merged"
+          fi
+          herd integrator cleanup --pr "$PR_NUMBER" $MERGED_FLAG
 
   handle-comment:
     if: >


### PR DESCRIPTION
## Summary
- The integrator cleanup job had `merged == true` in its workflow condition, so closing a batch PR without merging never triggered cleanup (issues weren't cancelled/closed, milestone wasn't closed, branch wasn't deleted)
- Removed the `merged == true` filter and now passes `--merged` flag dynamically based on the actual event data
- Fixed in both the repo workflow and the `herd init` template

## Test plan
- [x] Existing `TestCleanupClosed` covers both merged and close-without-merge paths at the Go level
- [ ] Close a `[herd]` batch PR without merging and verify issues get labelled `herd/status:cancelled` and closed