### PR TITLE
Fix advance not dispatching remaining ready issues in same tier

### DIFF
--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -322,8 +322,23 @@ func Advance(ctx context.Context, p platform.Platform, g *git.Git, cfg *config.C
 		}
 	}
 
-	if tierStuck || !tierComplete {
+	if tierStuck {
 		return &AdvanceResult{TierComplete: false}, nil
+	}
+
+	if !tierComplete {
+		// Tier not done yet — but there may be ready issues that weren't dispatched
+		// due to concurrency limits on the previous advance. Try to dispatch them now.
+		dispatched, err := dispatchReadyIssues(ctx, p, cfg, tiers[triggerTier], allIssues, batchBranch)
+		if err != nil {
+			return nil, fmt.Errorf("dispatching remaining tier issues: %w", err)
+		}
+		if dispatched > 0 {
+			fmt.Printf("Tier %d not yet complete. Dispatched %d remaining issues.\n", triggerTier, dispatched)
+		} else {
+			fmt.Printf("Tier %d not yet complete.\n", triggerTier)
+		}
+		return &AdvanceResult{TierComplete: false, DispatchedCount: dispatched}, nil
 	}
 
 	// Tier is complete — check if this was the last tier
@@ -337,22 +352,33 @@ func Advance(ctx context.Context, p platform.Platform, g *git.Git, cfg *config.C
 	}
 
 	// Dispatch next tier
-	nextTier := tiers[triggerTier+1]
-	dispatched := 0
+	dispatched, err := dispatchReadyIssues(ctx, p, cfg, tiers[triggerTier+1], allIssues, batchBranch)
+	if err != nil {
+		return nil, fmt.Errorf("dispatching next tier: %w", err)
+	}
 
-	// Count active workers for concurrency limit
+	return &AdvanceResult{
+		TierComplete:    true,
+		DispatchedCount: dispatched,
+	}, nil
+}
+
+// dispatchReadyIssues dispatches ready/blocked issues from a tier, respecting
+// concurrency limits. Returns the number of issues dispatched.
+func dispatchReadyIssues(ctx context.Context, p platform.Platform, cfg *config.Config, tierIssues []int, allIssues []*platform.Issue, batchBranch string) (int, error) {
 	activeRuns, err := p.Workflows().ListRuns(ctx, platform.RunFilters{Status: "in_progress"})
 	if err != nil {
-		return nil, fmt.Errorf("counting active workers: %w", err)
+		return 0, fmt.Errorf("counting active workers: %w", err)
 	}
 	remaining := cfg.Workers.MaxConcurrent - len(activeRuns)
 
 	defaultBranch, err := p.Repository().GetDefaultBranch(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting default branch: %w", err)
+		return 0, fmt.Errorf("getting default branch: %w", err)
 	}
 
-	for _, num := range nextTier {
+	dispatched := 0
+	for _, num := range tierIssues {
 		issue := findIssue(allIssues, num)
 		if issue == nil {
 			continue
@@ -404,11 +430,7 @@ func Advance(ctx context.Context, p platform.Platform, g *git.Git, cfg *config.C
 		}
 		dispatched++
 	}
-
-	return &AdvanceResult{
-		TierComplete:    true,
-		DispatchedCount: dispatched,
-	}, nil
+	return dispatched, nil
 }
 
 // buildTiersFromIssues parses issue front matter to build a DAG and compute tiers.
@@ -505,53 +527,10 @@ func AdvanceByBatch(ctx context.Context, p platform.Platform, g *git.Git, cfg *c
 		return &AdvanceResult{AllComplete: true, TierComplete: true, BatchPRNumber: prNum}, nil
 	}
 
-	// Dispatch next tier's blocked issues
-	dispatched := 0
-	activeRuns, err := p.Workflows().ListRuns(ctx, platform.RunFilters{Status: "in_progress"})
+	// Dispatch incomplete tier's blocked/ready issues
+	dispatched, err := dispatchReadyIssues(ctx, p, cfg, tiers[incompleteTier], allIssues, batchBranch)
 	if err != nil {
-		return nil, fmt.Errorf("counting active workers: %w", err)
-	}
-	remaining := cfg.Workers.MaxConcurrent - len(activeRuns)
-
-	defaultBranch, err := p.Repository().GetDefaultBranch(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting default branch: %w", err)
-	}
-
-	for _, num := range tiers[incompleteTier] {
-		issue := findIssue(allIssues, num)
-		if issue == nil {
-			continue
-		}
-		if issues.HasLabel(issue.Labels, issues.TypeManual) {
-			continue
-		}
-
-		status := issues.StatusLabel(issue.Labels)
-		if status != issues.StatusBlocked {
-			continue
-		}
-
-		_ = p.Issues().RemoveLabels(ctx, num, []string{issues.StatusBlocked})
-
-		if dispatched >= remaining {
-			_ = p.Issues().AddLabels(ctx, num, []string{issues.StatusReady})
-			continue
-		}
-
-		_ = p.Issues().AddLabels(ctx, num, []string{issues.StatusInProgress})
-		_, err := p.Workflows().Dispatch(ctx, "herd-worker.yml", defaultBranch, map[string]string{
-			"issue_number":    fmt.Sprintf("%d", num),
-			"batch_branch":    batchBranch,
-			"timeout_minutes": fmt.Sprintf("%d", cfg.Workers.TimeoutMinutes),
-			"runner_label":    cfg.Workers.RunnerLabel,
-		})
-		if err != nil {
-			_ = p.Issues().RemoveLabels(ctx, num, []string{issues.StatusInProgress})
-			_ = p.Issues().AddLabels(ctx, num, []string{issues.StatusFailed})
-			continue
-		}
-		dispatched++
+		return nil, fmt.Errorf("dispatching tier issues: %w", err)
 	}
 
 	return &AdvanceResult{

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -618,6 +618,58 @@ func TestAdvance_DispatchesReadyIssues(t *testing.T) {
 	assert.Contains(t, issueSvc.addedLabels[13], issues.StatusInProgress)
 }
 
+func TestAdvance_DispatchesRemainingInSameTier(t *testing.T) {
+	// When a worker completes but other issues in the same tier are still ready
+	// (because concurrency limits prevented dispatching them earlier), advance
+	// should dispatch the remaining ready issues.
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[11] = &platform.Issue{
+		Number: 11, Title: "Task B",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+	issueSvc.listResult = []*platform.Issue{
+		// Tier 0: done
+		{Number: 10, Title: "Task A", Labels: []string{issues.StatusDone},
+			Body: "---\nherd:\n  version: 1\n  batch: 1\n---\n\n## Task\nDo A\n"},
+		// Tier 1: triggering issue is done, but two others still ready
+		{Number: 11, Title: "Task B", Labels: []string{issues.StatusDone},
+			Body: "---\nherd:\n  version: 1\n  batch: 1\n  depends_on: [10]\n---\n\n## Task\nDo B\n"},
+		{Number: 12, Title: "Task C", Labels: []string{issues.StatusReady},
+			Body: "---\nherd:\n  version: 1\n  batch: 1\n  depends_on: [10]\n---\n\n## Task\nDo C\n"},
+		{Number: 13, Title: "Task D", Labels: []string{issues.StatusReady},
+			Body: "---\nherd:\n  version: 1\n  batch: 1\n  depends_on: [10]\n---\n\n## Task\nDo D\n"},
+	}
+
+	wf := &mockWorkflowService{
+		runs: map[int64]*platform.Run{
+			200: {ID: 200, Conclusion: "success", Inputs: map[string]string{"issue_number": "11"}},
+		},
+		listResult: []*platform.Run{}, // no active workers
+	}
+
+	mock := &mockPlatform{
+		issues:     issueSvc,
+		prs:        &mockPRService{},
+		workflows:  wf,
+		repo:       &mockRepoService{defaultBranch: "main"},
+		milestones: &mockMilestoneService{},
+	}
+
+	cfg := &config.Config{Workers: config.Workers{MaxConcurrent: 5, TimeoutMinutes: 30, RunnerLabel: "herd-worker"}}
+
+	result, err := Advance(context.Background(), mock, nil, cfg, AdvanceParams{RunID: 200})
+	require.NoError(t, err)
+	assert.False(t, result.TierComplete)
+	assert.Equal(t, 2, result.DispatchedCount)
+	// Both ready issues should be dispatched
+	assert.Contains(t, issueSvc.removedLabels[12], issues.StatusReady)
+	assert.Contains(t, issueSvc.addedLabels[12], issues.StatusInProgress)
+	assert.Contains(t, issueSvc.removedLabels[13], issues.StatusReady)
+	assert.Contains(t, issueSvc.addedLabels[13], issues.StatusInProgress)
+	assert.Len(t, wf.dispatched, 2)
+}
+
 func TestAdvance_TierStuck(t *testing.T) {
 	issueSvc := newMockIssueService()
 	issueSvc.getResult[10] = &platform.Issue{


### PR DESCRIPTION
## Summary
- When concurrency limits prevented dispatching all tier issues on first advance, subsequent worker completions returned "tier not yet complete" without dispatching the remaining `ready` issues — they stayed ready forever
- Now `Advance` dispatches remaining ready/blocked issues in the current tier when it's incomplete but not stuck
- Extracted `dispatchReadyIssues` helper shared by both `Advance` and `AdvanceByBatch`

## Test plan
- [x] New test `TestAdvance_DispatchesRemainingInSameTier` — worker completes in a tier with 2 remaining ready issues, both get dispatched
- [x] All existing advance tests pass
- [x] Full test suite passes