### PR TITLE
Add review_fix_severity config for fix worker threshold

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ integrator:
   review: true                   # agent reviews batch PRs before merge
   review_max_fix_cycles: 3       # max fix-and-re-review cycles (reviewer reads its prior comments to avoid contradictions)
   review_strictness: "standard"  # standard | strict | lenient
+  review_fix_severity: "medium"  # minimum severity to create fix workers: high | medium | low
   ci_max_fix_cycles: 2           # max CI-failure fix cycles (0 = notify-only)
 
 monitor:

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -159,6 +159,8 @@ func flattenConfig(cfg *config.Config) []keyValue {
 	kvs = append(kvs, keyValue{"integrator.require_ci", btoa(cfg.Integrator.RequireCI)})
 	kvs = append(kvs, keyValue{"integrator.review", btoa(cfg.Integrator.Review)})
 	kvs = append(kvs, keyValue{"integrator.review_max_fix_cycles", itoa(cfg.Integrator.ReviewMaxFixCycles)})
+	kvs = append(kvs, keyValue{"integrator.review_strictness", displayValue(cfg.Integrator.ReviewStrictness)})
+	kvs = append(kvs, keyValue{"integrator.review_fix_severity", displayValue(cfg.Integrator.ReviewFixSeverity)})
 	kvs = append(kvs, keyValue{"integrator.ci_max_fix_cycles", itoa(cfg.Integrator.CIMaxFixCycles)})
 	kvs = append(kvs, keyValue{"monitor.patrol_interval_minutes", itoa(cfg.Monitor.PatrolIntervalMinutes)})
 	kvs = append(kvs, keyValue{"monitor.stale_threshold_minutes", itoa(cfg.Monitor.StaleThresholdMinutes)})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,8 @@ type Integrator struct {
 	RequireCI                      bool   `yaml:"require_ci"`
 	Review                         bool   `yaml:"review"`
 	ReviewMaxFixCycles             int    `yaml:"review_max_fix_cycles"`
-	ReviewStrictness               string `yaml:"review_strictness"` // "standard", "strict", "lenient"
+	ReviewStrictness               string `yaml:"review_strictness"`    // "standard", "strict", "lenient"
+	ReviewFixSeverity              string `yaml:"review_fix_severity"`  // minimum severity to fix: "high", "medium", "low" (default: "medium")
 	CIMaxFixCycles                 int    `yaml:"ci_max_fix_cycles"`
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -23,6 +23,7 @@ func Default() *Config {
 			Review:                        true,
 			ReviewMaxFixCycles:            10,
 			ReviewStrictness:              "standard",
+			ReviewFixSeverity:             "medium",
 			CIMaxFixCycles:                10,
 		},
 		Monitor: Monitor{

--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -248,10 +248,19 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 		return &ReviewResult{MaxCyclesHit: true, BatchPRNumber: pr.Number}, nil
 	}
 
-	// Combine HIGH and MEDIUM findings for fix dispatch — only LOW is informational
-	actionableFindings := make([]agent.ReviewFinding, 0, len(highFindings)+len(mediumFindings))
+	// Combine findings for fix dispatch based on configured minimum severity
+	actionableFindings := make([]agent.ReviewFinding, 0, len(highFindings)+len(mediumFindings)+len(lowFindings))
 	actionableFindings = append(actionableFindings, highFindings...)
-	actionableFindings = append(actionableFindings, mediumFindings...)
+	minSeverity := strings.ToLower(cfg.Integrator.ReviewFixSeverity)
+	if minSeverity == "" {
+		minSeverity = "medium"
+	}
+	if minSeverity == "medium" || minSeverity == "low" {
+		actionableFindings = append(actionableFindings, mediumFindings...)
+	}
+	if minSeverity == "low" {
+		actionableFindings = append(actionableFindings, lowFindings...)
+	}
 
 	// No actionable findings — approve with informational comment and batch summary
 	if len(actionableFindings) == 0 {
@@ -289,7 +298,7 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 		return &ReviewResult{Approved: true, BatchPRNumber: pr.Number}, nil
 	}
 
-	// Create single batched fix issue with all actionable findings (HIGH + MEDIUM)
+	// Create single batched fix issue with all actionable findings
 	nextCycle := currentCycle + 1
 
 	var fixTaskBuilder strings.Builder
@@ -336,7 +345,7 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 	_ = p.PullRequests().AddComment(ctx, pr.Number, findingsComment)
 
 	// Block merge with Request Changes review
-	reviewBody := fmt.Sprintf("Found %d actionable issues (HIGH+MEDIUM). Fix worker dispatched → #%d.", len(actionableFindings), fixIssue.Number)
+	reviewBody := fmt.Sprintf("Found %d actionable issues. Fix worker dispatched → #%d.", len(actionableFindings), fixIssue.Number)
 	_ = p.PullRequests().CreateReview(ctx, pr.Number, reviewBody, platform.ReviewRequestChanges)
 
 	return &ReviewResult{

--- a/internal/integrator/review_test.go
+++ b/internal/integrator/review_test.go
@@ -193,6 +193,76 @@ func TestReview_ChangesRequested_CreatesFixes(t *testing.T) {
 	assert.Equal(t, "Review fixes (cycle 1)", createdIssues[0].Title)
 }
 
+func TestReview_LowSeverityIncludedWhenConfigured(t *testing.T) {
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = &platform.Issue{
+		Number: 42, Title: "Test",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+	issueSvc.listResult = []*platform.Issue{
+		{Number: 42, Body: "---\nherd:\n  version: 1\n---\n\n## Task\nDo it\n"},
+	}
+	createdIssues := []*platform.Issue{}
+	nextNum := 100
+
+	wf := &mockWorkflowService{
+		runs: map[int64]*platform.Run{
+			100: {ID: 100, Conclusion: "success", Inputs: map[string]string{"issue_number": "42"}},
+		},
+	}
+
+	mockCreate := &mockIssueServiceWithCreate{
+		mockIssueService: issueSvc,
+		onCreate: func(title, body string, labels []string, milestone *int) (*platform.Issue, error) {
+			iss := &platform.Issue{Number: nextNum, Title: title, Body: body}
+			nextNum++
+			createdIssues = append(createdIssues, iss)
+			return iss, nil
+		},
+	}
+
+	mock := &mockPlatform{
+		issues: mockCreate,
+		prs: &mockPRService{
+			listResult: []*platform.PullRequest{{Number: 50, Title: "[herd] Batch"}},
+		},
+		workflows:  wf,
+		repo:       &mockRepoService{defaultBranch: "main"},
+		milestones: &mockMilestoneService{},
+	}
+
+	ag := &mockReviewAgent{
+		reviewResult: &agent.ReviewResult{
+			Approved: false,
+			Findings: []agent.ReviewFinding{
+				{Severity: "LOW", Description: "Minor style issue in utils.go"},
+			},
+			Comments: []string{"Minor style issue"},
+		},
+	}
+
+	dir, g := initTestRepo(t)
+
+	// With default config (medium), LOW findings should NOT create fix issues
+	result, err := Review(context.Background(), mock, ag, g, &config.Config{
+		Integrator: config.Integrator{Review: true, ReviewMaxFixCycles: 3, ReviewFixSeverity: "medium"},
+	}, ReviewParams{RunID: 100, RepoRoot: dir})
+	require.NoError(t, err)
+	assert.True(t, result.Approved)
+	assert.Len(t, createdIssues, 0)
+
+	// With review_fix_severity: low, LOW findings SHOULD create fix issues
+	createdIssues = nil
+	result, err = Review(context.Background(), mock, ag, g, &config.Config{
+		Integrator: config.Integrator{Review: true, ReviewMaxFixCycles: 3, ReviewFixSeverity: "low"},
+	}, ReviewParams{RunID: 100, RepoRoot: dir})
+	require.NoError(t, err)
+	assert.False(t, result.Approved)
+	assert.Len(t, createdIssues, 1)
+	assert.Len(t, wf.dispatched, 1)
+}
+
 func TestReview_SkipsWhenFixWorkersInProgress(t *testing.T) {
 	issueSvc := newMockIssueService()
 	issueSvc.getResult[42] = &platform.Issue{


### PR DESCRIPTION
## Summary
- New `integrator.review_fix_severity` config: `high`, `medium` (default), or `low`
- When set to `low`, all findings including LOW severity create fix workers instead of being informational only
- Also added missing `review_strictness` and `review_fix_severity` to `herd config list` output

## Test plan
- [x] `TestReview_LowSeverityIncludedWhenConfigured` — LOW-only findings approved with `medium`, fix worker created with `low`
- [x] Full test suite passes