### PR TITLE
Fix false conflict detection and stale rebase-pending label

### DIFF
--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -224,6 +224,9 @@ func Consolidate(ctx context.Context, p platform.Platform, g *git.Git, cfg *conf
 		}, nil
 	}
 
+	// Remove rebase-pending label from batch PR if present
+	removeBatchPRRebasePending(ctx, p, batchBranch)
+
 	// Close stale conflict/rebase issues whose worker branches no longer exist
 	closeStaleConflictIssues(ctx, p, issue.Milestone)
 
@@ -557,6 +560,20 @@ func findIssue(allIssues []*platform.Issue, number int) *platform.Issue {
 // milestone whose worker branches have already been consolidated or deleted.
 // This prevents the monitor from retrying stale issues that would fail with
 // non-fast-forward errors.
+// removeBatchPRRebasePending removes the rebase-pending label from the batch PR
+// after a successful consolidation push.
+func removeBatchPRRebasePending(ctx context.Context, p platform.Platform, batchBranch string) {
+	prSvc := p.PullRequests()
+	if prSvc == nil {
+		return
+	}
+	prs, err := prSvc.List(ctx, platform.PRFilters{State: "open", Head: batchBranch})
+	if err != nil || len(prs) == 0 {
+		return
+	}
+	_ = p.Issues().RemoveLabels(ctx, prs[0].Number, []string{issues.RebasePending})
+}
+
 func closeStaleConflictIssues(ctx context.Context, p platform.Platform, ms *platform.Milestone) {
 	allIssues, err := p.Issues().List(ctx, platform.IssueFilters{
 		State:     "open",

--- a/internal/monitor/patrol.go
+++ b/internal/monitor/patrol.go
@@ -196,6 +196,11 @@ func Patrol(ctx context.Context, p platform.Platform, cfg *config.Config) (*Patr
 			if getErr != nil {
 				continue
 			}
+			if !fullPR.MergeableKnown {
+				// GitHub is still computing mergeability (e.g., right after a force push).
+				// Skip — we'll check again on the next patrol.
+				continue
+			}
 			if fullPR.Mergeable {
 				// Conflict resolved — clean up label
 				_ = p.Issues().RemoveLabels(ctx, pr.Number, []string{issues.RebasePending})

--- a/internal/monitor/patrol_test.go
+++ b/internal/monitor/patrol_test.go
@@ -168,7 +168,7 @@ func (m *mockPRService) Get(_ context.Context, number int) (*platform.PullReques
 	if pr, ok := m.getResults[number]; ok {
 		return pr, nil
 	}
-	return &platform.PullRequest{Number: number, Mergeable: true}, nil
+	return &platform.PullRequest{Number: number, Mergeable: true, MergeableKnown: true}, nil
 }
 func (m *mockPRService) List(_ context.Context, _ platform.PRFilters) ([]*platform.PullRequest, error) {
 	return m.listResult, nil
@@ -1576,7 +1576,7 @@ func TestPatrol_ConflictDetectedOnBatchPR(t *testing.T) {
 		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
 	// Get returns non-mergeable PR
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 	issueSvc.createResult = &platform.Issue{Number: 999}
@@ -1609,13 +1609,45 @@ func TestPatrol_ConflictDetectedOnBatchPR(t *testing.T) {
 	assert.Len(t, wf.dispatched, 1)
 }
 
+func TestPatrol_MergeableUnknown_SkipsConflictCheck(t *testing.T) {
+	prSvc := newMockPRService()
+	prSvc.listResult = []*platform.PullRequest{
+		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
+	}
+	// GitHub hasn't computed mergeability yet (e.g., right after a force push)
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: false}
+
+	issueSvc := newMockIssueService()
+	wf := &mockWorkflowService{}
+
+	mock := &mockPlatform{
+		issues:     issueSvc,
+		prs:        prSvc,
+		workflows:  wf,
+		repo:       &mockRepoService{defaultBranch: "main"},
+		milestones: &mockMilestoneService{},
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{MaxConflictResolutionAttempts: 3},
+		Workers:    config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"},
+	}
+
+	result, err := Patrol(context.Background(), mock, cfg)
+	require.NoError(t, err)
+	// Should NOT detect a conflict when mergeability is unknown
+	assert.Equal(t, 0, result.ConflictDetected)
+	assert.Empty(t, issueSvc.addedLabels[10])
+	assert.Empty(t, wf.dispatched)
+}
+
 func TestPatrol_ConflictResolved_LabelRemoved(t *testing.T) {
 	prSvc := newMockPRService()
 	prSvc.listResult = []*platform.PullRequest{
 		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
 	// Get returns mergeable PR
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: true}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: true, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 
@@ -1640,7 +1672,7 @@ func TestPatrol_ConflictWithRebasePendingLabel_NoDuplicate(t *testing.T) {
 	prSvc.listResult = []*platform.PullRequest{
 		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 	// Simulate herd/rebase-pending label already present
@@ -1672,7 +1704,7 @@ func TestPatrol_ConflictDispatchFailure_LabelRemoved(t *testing.T) {
 	prSvc.listResult = []*platform.PullRequest{
 		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 	// Make issue creation fail, which will cause the dispatch to fail
@@ -1749,7 +1781,7 @@ func TestPatrol_ConflictDetection_LabelAddedBeforeDispatch(t *testing.T) {
 	prSvc.listResult = []*platform.PullRequest{
 		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 	issueSvc.createResult = &platform.Issue{Number: 999}
@@ -1788,7 +1820,7 @@ func TestPatrol_ConflictDetection_NonHerdPR_Ignored(t *testing.T) {
 		{Number: 10, Title: "Normal PR", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
 	// If Get were called, it would return non-mergeable — but it should never be called
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 
@@ -1814,7 +1846,7 @@ func TestPatrol_ConflictDetection_MaxAttemptsReached(t *testing.T) {
 	prSvc.listResult = []*platform.PullRequest{
 		{Number: 10, Title: "[herd] Batch 1", Head: "herd/batch/1-batch", CreatedAt: time.Now()},
 	}
-	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false}
+	prSvc.getResults[10] = &platform.PullRequest{Number: 10, Head: "herd/batch/1-batch", Mergeable: false, MergeableKnown: true}
 
 	issueSvc := newMockIssueService()
 	issueSvc.createResult = &platform.Issue{Number: 999}

--- a/internal/platform/github/pullrequests.go
+++ b/internal/platform/github/pullrequests.go
@@ -158,7 +158,8 @@ func mapPullRequest(pr *gh.PullRequest) *platform.PullRequest {
 		State:     pr.GetState(),
 		Head:      pr.GetHead().GetRef(),
 		Base:      pr.GetBase().GetRef(),
-		Mergeable: pr.GetMergeable(),
+		Mergeable:      pr.GetMergeable(),
+		MergeableKnown: pr.Mergeable != nil,
 		URL:       pr.GetHTMLURL(),
 		CreatedAt: pr.GetCreatedAt().Time,
 	}

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -21,7 +21,8 @@ type PullRequest struct {
 	State     string // "open", "closed", "merged"
 	Head      string // branch name
 	Base      string // target branch
-	Mergeable bool
+	Mergeable        bool
+	MergeableKnown   bool // false when GitHub is still computing mergeability
 	URL       string
 	CreatedAt time.Time
 }


### PR DESCRIPTION
## Summary
- GitHub returns `null` for `mergeable` while recomputing after a force push. `GetMergeable()` treats `nil` as `false`, causing the monitor to dispatch a rebase worker for non-existent conflicts.
- Added `MergeableKnown` field to `PullRequest` type — set from `pr.Mergeable != nil`. Monitor skips conflict detection when mergeability is unknown.
- Integrator now removes the `rebase-pending` label from the batch PR after a successful consolidation push, instead of relying on the next monitor patrol to clean it up.

## Test plan
- [x] `TestPatrol_MergeableUnknown_SkipsConflictCheck` — unknown mergeability does not trigger conflict detection
- [x] All existing monitor, integrator, and platform tests pass
- [x] Full test suite passes