### PR TITLE
Add check-ci after review in integrator workflow

### DIFF
--- a/.github/workflows/herd-integrator.yml
+++ b/.github/workflows/herd-integrator.yml
@@ -49,6 +49,7 @@ jobs:
           herd integrator consolidate --run-id "$RUN_ID"
           herd integrator advance --run-id "$RUN_ID"
           herd integrator review --run-id "$RUN_ID"
+          herd integrator check-ci --run-id "$RUN_ID"
 
   check-ci-on-completion:
     if: >
@@ -109,6 +110,7 @@ jobs:
           if [ -n "$BATCH" ]; then
             herd integrator advance --batch "$BATCH"
             herd integrator review --batch "$BATCH"
+            herd integrator check-ci --batch "$BATCH"
           else
             echo "Not a herd issue — skipping."
           fi

--- a/internal/cli/workflows/herd-integrator.yml
+++ b/internal/cli/workflows/herd-integrator.yml
@@ -49,6 +49,7 @@ jobs:
           herd integrator consolidate --run-id "$RUN_ID"
           herd integrator advance --run-id "$RUN_ID"
           herd integrator review --run-id "$RUN_ID"
+          herd integrator check-ci --run-id "$RUN_ID"
 
   check-ci-on-completion:
     if: >
@@ -109,6 +110,7 @@ jobs:
           if [ -n "$BATCH" ]; then
             herd integrator advance --batch "$BATCH"
             herd integrator review --batch "$BATCH"
+            herd integrator check-ci --batch "$BATCH"
           else
             echo "Not a herd issue — skipping."
           fi


### PR DESCRIPTION
## Summary
- The `check_run` event doesn't fire for same-repo GitHub Actions (anti-recursion), so CI failures on batch branches were never automatically detected
- Added `herd integrator check-ci` after review in the `integrate` and `advance-on-close` jobs
- If CI already failed, a fix worker is dispatched immediately; if still pending, it's a no-op

## Test plan
- [x] `CheckCI` with `--run-id` and `--batch` paths already have full test coverage (success, pending, failure, max cycles)
- [x] Full test suite passes
- [ ] Verify on next batch that CI failures are detected without needing manual `/herd fix-ci`