### PR TITLE
Pass review_fix_severity to agent prompt for approval threshold

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -73,6 +73,7 @@ type ReviewOptions struct {
 	RepoRoot            string
 	SystemPrompt        string
 	Strictness          string   // "standard", "strict", "lenient" — controls review aggressiveness
+	MinFixSeverity      string   // minimum severity that blocks approval: "high", "medium", "low"
 	PriorReviewComments []string // Full text of previous HerdOS review comments on this PR
 }
 

--- a/internal/agent/claude/review.go
+++ b/internal/agent/claude/review.go
@@ -43,7 +43,8 @@ The following review comments were posted in previous cycles on this PR. Do NOT 
 Respond with ONLY a JSON object (no markdown fencing, no extra text):
 {"approved": true, "findings": [], "summary": "brief summary"}
 
-If you find issues, set approved to false and classify each finding as HIGH, MEDIUM, or LOW severity:
+If you find issues, classify each finding as HIGH, MEDIUM, or LOW severity.
+{{if .MinFixSeverity}}Set approved to false if ANY finding is {{.MinFixSeverityDesc}} severity or higher. Only set approved to true if all findings are below {{.MinFixSeverityDesc}} severity.{{else}}Set approved to false if any finding is MEDIUM or HIGH severity.{{end}}
 {"approved": false, "findings": [{"severity": "HIGH", "description": "issue description"}, {"severity": "MEDIUM", "description": "minor issue"}], "summary": "brief summary of findings"}
 Use severity "CRITERIA" only when the acceptance criterion itself is flawed, not the code.
 
@@ -65,6 +66,8 @@ type reviewPromptData struct {
 	RoleInstructions    string
 	Strictness          string
 	StrictnessUpper     string
+	MinFixSeverity      string
+	MinFixSeverityDesc  string
 	PriorReviewComments []string
 }
 
@@ -142,11 +145,25 @@ func renderReviewPrompt(diff string, opts agent.ReviewOptions) (string, error) {
 		strictness = "standard"
 	}
 
+	minSev := strings.ToUpper(opts.MinFixSeverity)
+	sevDesc := ""
+	switch minSev {
+	case "LOW":
+		sevDesc = "LOW"
+	case "HIGH":
+		sevDesc = "HIGH"
+	default:
+		minSev = ""
+		sevDesc = ""
+	}
+
 	data := reviewPromptData{
 		AcceptanceCriteria:  opts.AcceptanceCriteria,
 		Diff:                diff,
 		Strictness:          strictness,
 		StrictnessUpper:     strings.ToUpper(strictness),
+		MinFixSeverity:      minSev,
+		MinFixSeverityDesc:  sevDesc,
 		PriorReviewComments: opts.PriorReviewComments,
 	}
 

--- a/internal/agent/claude/review_test.go
+++ b/internal/agent/claude/review_test.go
@@ -220,6 +220,26 @@ func TestRenderReviewPrompt_SeverityGuide(t *testing.T) {
 	assert.Contains(t, prompt, "CRITERIA: An acceptance criterion itself is wrong")
 }
 
+func TestRenderReviewPrompt_MinFixSeverity(t *testing.T) {
+	// Default (medium) — no special instruction, uses fallback
+	opts := agent.ReviewOptions{AcceptanceCriteria: []string{"works"}}
+	prompt, err := renderReviewPrompt("diff", opts)
+	require.NoError(t, err)
+	assert.Contains(t, prompt, "MEDIUM or HIGH severity")
+
+	// Low — tells agent to reject on LOW or higher
+	opts.MinFixSeverity = "low"
+	prompt, err = renderReviewPrompt("diff", opts)
+	require.NoError(t, err)
+	assert.Contains(t, prompt, "LOW severity or higher")
+
+	// High — tells agent to reject only on HIGH
+	opts.MinFixSeverity = "high"
+	prompt, err = renderReviewPrompt("diff", opts)
+	require.NoError(t, err)
+	assert.Contains(t, prompt, "HIGH severity or higher")
+}
+
 func TestRenderReviewPrompt_CriteriaSeverityGuide(t *testing.T) {
 	opts := agent.ReviewOptions{AcceptanceCriteria: []string{"works"}}
 	prompt, err := renderReviewPrompt("diff", opts)

--- a/internal/integrator/review.go
+++ b/internal/integrator/review.go
@@ -175,6 +175,7 @@ func Review(ctx context.Context, p platform.Platform, ag agent.Agent, g *git.Git
 		AcceptanceCriteria:  allCriteria,
 		RepoRoot:            params.RepoRoot,
 		Strictness:          cfg.Integrator.ReviewStrictness,
+		MinFixSeverity:      cfg.Integrator.ReviewFixSeverity,
 		PriorReviewComments: priorReviewComments,
 	}
 


### PR DESCRIPTION
## Summary
- The agent was approving reviews with MEDIUM findings listed as informational, even when `review_fix_severity` was set to `low`
- The config only controlled server-side filtering of findings for fix dispatch, but the agent prompt never mentioned which severities should block approval
- Now `MinFixSeverity` is passed to the review prompt, telling the agent to set `approved: false` when findings meet the configured threshold

## Test plan
- [x] `TestRenderReviewPrompt_MinFixSeverity` — verifies prompt contains correct severity instructions for low, medium (default), and high
- [x] Full test suite passes