### PR TITLE
Add /herd dispatch comment command

### DIFF
--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -795,7 +795,8 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 | Command | Context | Description |
 |---------|---------|-------------|
 | `/herd fix-ci` | Issue or PR | Check CI status and dispatch a fix worker if CI failed |
-| `/herd retry <N>` | Issue or PR | Re-dispatch a failed issue's worker |
+| `/herd retry` | Issue | Re-dispatch the current failed issue's worker |
+| `/herd retry <N>` | Issue or PR | Re-dispatch failed issue #N's worker |
 | `/herd review` | PR | Trigger an agent review of the batch PR |
 | `/herd fix <description>` | PR | Create a fix issue from the description and dispatch a worker |
 | `/herd integrate` | Issue or PR | Run the full integrator cycle: consolidate → check CI → advance → review |

--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -790,6 +790,20 @@ Commands are accepted from users with `OWNER`, `MEMBER`, or `COLLABORATOR` assoc
 
 ### Monitor Integration
 
+### Available Commands
+
+| Command | Context | Description |
+|---------|---------|-------------|
+| `/herd fix-ci` | Issue or PR | Check CI status and dispatch a fix worker if CI failed |
+| `/herd retry <N>` | Issue or PR | Re-dispatch a failed issue's worker |
+| `/herd review` | PR | Trigger an agent review of the batch PR |
+| `/herd fix <description>` | PR | Create a fix issue from the description and dispatch a worker |
+| `/herd integrate` | Issue or PR | Run the full integrator cycle: consolidate → check CI → advance → review |
+| `/herd dispatch` | Issue | Dispatch the current issue (must be ready or blocked) |
+| `/herd dispatch <N>` | Issue or PR | Dispatch issue #N (must be ready or blocked) |
+
+### Monitor Integration
+
 The Monitor posts `/herd retry <N>` and `/herd fix-ci` comments instead of dispatching workflows directly. This ensures all command execution flows through the same handler, maintaining single responsibility.
 
 ### Failure Recovery

--- a/internal/commands/dispatch.go
+++ b/internal/commands/dispatch.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/herd-os/herd/internal/issues"
+	"github.com/herd-os/herd/internal/planner"
+)
+
+func handleDispatch(hctx *HandlerContext, cmd Command) Result {
+	// Determine which issue to dispatch — either from args or the current issue
+	var issueNum int
+	if len(cmd.Args) > 0 {
+		n, err := strconv.Atoi(cmd.Args[0])
+		if err != nil {
+			return Result{Message: fmt.Sprintf("⚠️ Invalid issue number: %s", cmd.Args[0])}
+		}
+		issueNum = n
+	} else {
+		if hctx.IsPR {
+			return Result{Message: "⚠️ `/herd dispatch` on a PR requires an issue number: `/herd dispatch <issue-number>`"}
+		}
+		issueNum = hctx.IssueNumber
+	}
+
+	issue, err := hctx.Platform.Issues().Get(hctx.Ctx, issueNum)
+	if err != nil {
+		return Result{Error: fmt.Errorf("getting issue #%d: %w", issueNum, err)}
+	}
+
+	status := issues.StatusLabel(issue.Labels)
+	if status != issues.StatusReady && status != issues.StatusBlocked {
+		return Result{Message: fmt.Sprintf("⚠️ Issue #%d is not ready or blocked (status: %s).", issueNum, status)}
+	}
+	if issue.Milestone == nil {
+		return Result{Message: fmt.Sprintf("⚠️ Issue #%d has no milestone.", issueNum)}
+	}
+
+	batchBranch := fmt.Sprintf("herd/batch/%d-%s", issue.Milestone.Number, planner.Slugify(issue.Milestone.Title))
+
+	defaultBranch, err := hctx.Platform.Repository().GetDefaultBranch(hctx.Ctx)
+	if err != nil {
+		return Result{Error: fmt.Errorf("getting default branch: %w", err)}
+	}
+
+	// Remove current status and set in-progress
+	if status != "" {
+		_ = hctx.Platform.Issues().RemoveLabels(hctx.Ctx, issueNum, []string{status})
+	}
+	_ = hctx.Platform.Issues().AddLabels(hctx.Ctx, issueNum, []string{issues.StatusInProgress})
+
+	_, err = hctx.Platform.Workflows().Dispatch(hctx.Ctx, "herd-worker.yml", defaultBranch, map[string]string{
+		"issue_number":    fmt.Sprintf("%d", issueNum),
+		"batch_branch":    batchBranch,
+		"timeout_minutes": fmt.Sprintf("%d", hctx.Config.Workers.TimeoutMinutes),
+		"runner_label":    hctx.Config.Workers.RunnerLabel,
+	})
+	if err != nil {
+		_ = hctx.Platform.Issues().RemoveLabels(hctx.Ctx, issueNum, []string{issues.StatusInProgress})
+		_ = hctx.Platform.Issues().AddLabels(hctx.Ctx, issueNum, []string{status})
+		return Result{Error: fmt.Errorf("dispatching worker for #%d: %w", issueNum, err)}
+	}
+
+	return Result{Message: fmt.Sprintf("🚀 Dispatched worker for issue #%d.", issueNum)}
+}

--- a/internal/commands/dispatch_test.go
+++ b/internal/commands/dispatch_test.go
@@ -1,0 +1,134 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/herd-os/herd/internal/config"
+	"github.com/herd-os/herd/internal/issues"
+	"github.com/herd-os/herd/internal/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleDispatch_ReadyIssue(t *testing.T) {
+	issueSvc := newTestIssueService()
+	issueSvc.getResult[10] = &platform.Issue{
+		Number: 10, Title: "Task A",
+		Labels:    []string{issues.StatusReady, issues.TypeFeature},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	wf := &testWorkflowService{}
+	mock := &testPlatform{
+		issues:    issueSvc,
+		workflows: wf,
+		repo:      &testRepoService{defaultBranch: "main"},
+	}
+
+	hctx := &HandlerContext{
+		Ctx:         context.Background(),
+		Platform:    mock,
+		Config:      &config.Config{Workers: config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"}},
+		IssueNumber: 10,
+	}
+
+	result := handleDispatch(hctx, Command{Name: "dispatch"})
+	require.NoError(t, result.Error)
+	assert.Contains(t, result.Message, "Dispatched worker for issue #10")
+	assert.Contains(t, issueSvc.removedLabels[10], issues.StatusReady)
+	assert.Contains(t, issueSvc.addedLabels[10], issues.StatusInProgress)
+	assert.Len(t, wf.dispatched, 1)
+}
+
+func TestHandleDispatch_BlockedIssue(t *testing.T) {
+	issueSvc := newTestIssueService()
+	issueSvc.getResult[10] = &platform.Issue{
+		Number: 10, Title: "Task A",
+		Labels:    []string{issues.StatusBlocked, issues.TypeFeature},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	wf := &testWorkflowService{}
+	mock := &testPlatform{
+		issues:    issueSvc,
+		workflows: wf,
+		repo:      &testRepoService{defaultBranch: "main"},
+	}
+
+	hctx := &HandlerContext{
+		Ctx:         context.Background(),
+		Platform:    mock,
+		Config:      &config.Config{Workers: config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"}},
+		IssueNumber: 10,
+	}
+
+	result := handleDispatch(hctx, Command{Name: "dispatch"})
+	require.NoError(t, result.Error)
+	assert.Contains(t, result.Message, "Dispatched worker for issue #10")
+	assert.Contains(t, issueSvc.removedLabels[10], issues.StatusBlocked)
+	assert.Contains(t, issueSvc.addedLabels[10], issues.StatusInProgress)
+}
+
+func TestHandleDispatch_WithExplicitIssueNumber(t *testing.T) {
+	issueSvc := newTestIssueService()
+	issueSvc.getResult[20] = &platform.Issue{
+		Number: 20, Title: "Task B",
+		Labels:    []string{issues.StatusReady, issues.TypeFeature},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	wf := &testWorkflowService{}
+	mock := &testPlatform{
+		issues:    issueSvc,
+		workflows: wf,
+		repo:      &testRepoService{defaultBranch: "main"},
+	}
+
+	hctx := &HandlerContext{
+		Ctx:         context.Background(),
+		Platform:    mock,
+		Config:      &config.Config{Workers: config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"}},
+		IssueNumber: 5,
+	}
+
+	result := handleDispatch(hctx, Command{Name: "dispatch", Args: []string{"20"}})
+	require.NoError(t, result.Error)
+	assert.Contains(t, result.Message, "Dispatched worker for issue #20")
+}
+
+func TestHandleDispatch_RejectsDoneIssue(t *testing.T) {
+	issueSvc := newTestIssueService()
+	issueSvc.getResult[10] = &platform.Issue{
+		Number: 10, Title: "Task A",
+		Labels:    []string{issues.StatusDone},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	mock := &testPlatform{
+		issues: issueSvc,
+		repo:   &testRepoService{defaultBranch: "main"},
+	}
+
+	hctx := &HandlerContext{
+		Ctx:         context.Background(),
+		Platform:    mock,
+		Config:      &config.Config{},
+		IssueNumber: 10,
+	}
+
+	result := handleDispatch(hctx, Command{Name: "dispatch"})
+	assert.Contains(t, result.Message, "not ready or blocked")
+}
+
+func TestHandleDispatch_RejectsPRWithoutArgs(t *testing.T) {
+	hctx := &HandlerContext{
+		Ctx:         context.Background(),
+		Config:      &config.Config{},
+		IsPR:        true,
+		IssueNumber: 50,
+	}
+
+	result := handleDispatch(hctx, Command{Name: "dispatch"})
+	assert.Contains(t, result.Message, "requires an issue number")
+}

--- a/internal/commands/handlers_test.go
+++ b/internal/commands/handlers_test.go
@@ -512,6 +512,7 @@ func TestHandleRetry(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		isPR        bool
 		parseErr    error
 		setupIssue  *platform.Issue
 		dispatchErr error
@@ -524,9 +525,10 @@ func TestHandleRetry(t *testing.T) {
 			wantMsg:  "Could not parse command",
 		},
 		{
-			name:    "missing arg",
+			name:    "missing arg on PR",
 			args:    []string{},
-			wantMsg: "Usage: `/herd retry",
+			isPR:    true,
+			wantMsg: "requires an issue number",
 		},
 		{
 			name:    "invalid issue number",
@@ -549,6 +551,15 @@ func TestHandleRetry(t *testing.T) {
 				Number: 42, Labels: []string{issues.StatusFailed},
 			},
 			wantMsg: "no milestone",
+		},
+		{
+			name: "no arg on issue — uses current issue",
+			args: []string{},
+			setupIssue: &platform.Issue{
+				Number: 42, Labels: []string{issues.StatusFailed},
+				Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+			},
+			wantMsg: "Re-dispatched worker for issue #42",
 		},
 		{
 			name: "successful redispatch",
@@ -574,10 +585,16 @@ func TestHandleRetry(t *testing.T) {
 				repo:      &testRepoService{defaultBranch: "main"},
 			}
 
+			issueNum := 42
+			if tt.isPR {
+				issueNum = 0
+			}
 			hctx := &HandlerContext{
-				Ctx:      context.Background(),
-				Platform: p,
-				Config:   baseConfig(),
+				Ctx:         context.Background(),
+				Platform:    p,
+				Config:      baseConfig(),
+				IsPR:        tt.isPR,
+				IssueNumber: issueNum,
 			}
 			result := handleRetry(hctx, Command{Name: "retry", Args: tt.args, ParseErr: tt.parseErr})
 

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -8,5 +8,6 @@ func DefaultRegistry() *Registry {
 	r.Register("review", handleReview)
 	r.Register("fix", handleFix)
 	r.Register("integrate", handleIntegrate)
+	r.Register("dispatch", handleDispatch)
 	return r
 }

--- a/internal/commands/retry.go
+++ b/internal/commands/retry.go
@@ -12,12 +12,19 @@ func handleRetry(hctx *HandlerContext, cmd Command) Result {
 	if cmd.ParseErr != nil {
 		return Result{Message: "⚠️ Could not parse command: " + cmd.ParseErr.Error()}
 	}
-	if len(cmd.Args) < 1 {
-		return Result{Message: "⚠️ Usage: `/herd retry <issue-number>`"}
-	}
-	issueNum, err := strconv.Atoi(cmd.Args[0])
-	if err != nil {
-		return Result{Message: fmt.Sprintf("⚠️ Invalid issue number: %s", cmd.Args[0])}
+
+	var issueNum int
+	if len(cmd.Args) > 0 {
+		n, err := strconv.Atoi(cmd.Args[0])
+		if err != nil {
+			return Result{Message: fmt.Sprintf("⚠️ Invalid issue number: %s", cmd.Args[0])}
+		}
+		issueNum = n
+	} else {
+		if hctx.IsPR {
+			return Result{Message: "⚠️ `/herd retry` on a PR requires an issue number: `/herd retry <issue-number>`"}
+		}
+		issueNum = hctx.IssueNumber
 	}
 
 	issue, err := hctx.Platform.Issues().Get(hctx.Ctx, issueNum)


### PR DESCRIPTION
## Summary
- New `/herd dispatch` comment command to manually dispatch a ready or blocked issue
- `/herd dispatch` on an issue dispatches that issue
- `/herd dispatch <number>` from any issue or PR dispatches the specified issue
- Rejects issues that aren't ready or blocked, and PRs without an explicit issue number

## Test plan
- [x] `TestHandleDispatch_ReadyIssue` — dispatches ready issue, relabels to in-progress
- [x] `TestHandleDispatch_BlockedIssue` — dispatches blocked issue
- [x] `TestHandleDispatch_WithExplicitIssueNumber` — dispatches by number from different context
- [x] `TestHandleDispatch_RejectsDoneIssue` — rejects non-ready/blocked issues
- [x] `TestHandleDispatch_RejectsPRWithoutArgs` — rejects PR context without issue number
- [x] Full test suite passes