### PR TITLE
Fix CI failure detection and make /herd fix-ci force dispatch

### DIFF
--- a/internal/commands/fixci.go
+++ b/internal/commands/fixci.go
@@ -41,6 +41,7 @@ func handleFixCI(hctx *HandlerContext, cmd Command) Result {
 		RepoRoot:       hctx.RepoRoot,
 		UserContext:    cmd.Prompt,
 		BeforeDispatch: beforeDispatch,
+		Force:          true,
 	})
 	if err != nil {
 		return Result{Error: err}
@@ -52,8 +53,8 @@ func handleFixCI(hctx *HandlerContext, cmd Command) Result {
 		msg = "CI checking is disabled (`require_ci: false`)."
 	case result.Status == "success":
 		msg = "✅ CI is passing."
-	case result.Status == "pending":
-		msg = "⏳ CI is pending — re-ran failed checks."
+	case result.Status == "pending" && len(result.FixIssues) == 0:
+		msg = "⏳ CI is pending — no failures detected yet."
 	case result.MaxCyclesHit:
 		msg = "⚠️ CI failed — max fix cycles reached. Manual intervention needed."
 	case len(result.FixIssues) > 0:

--- a/internal/integrator/ci.go
+++ b/internal/integrator/ci.go
@@ -18,6 +18,7 @@ type CheckCIParams struct {
 	RepoRoot       string
 	UserContext    string // Optional hint from the user, prepended to fix issue body
 	BeforeDispatch func() // optional; called once, right before worker dispatch
+	Force          bool   // skip pending/success early return — treat any non-success as failure
 }
 
 // CheckCIResult holds the result of CI checking.
@@ -84,7 +85,10 @@ func CheckCI(ctx context.Context, p platform.Platform, cfg *config.Config, param
 		return nil, fmt.Errorf("getting CI status: %w", err)
 	}
 
-	if status == "success" || status == "pending" {
+	if status == "success" {
+		return &CheckCIResult{Status: status}, nil
+	}
+	if status == "pending" && !params.Force {
 		return &CheckCIResult{Status: status}, nil
 	}
 

--- a/internal/integrator/ci_test.go
+++ b/internal/integrator/ci_test.go
@@ -67,6 +67,7 @@ func TestCheckCI(t *testing.T) {
 		ciMaxCycles    int
 		existingCycles int
 		requireCI      bool
+		force          bool
 		expectStatus   string
 		expectSkipped  bool
 		expectMaxHit   bool
@@ -85,6 +86,15 @@ func TestCheckCI(t *testing.T) {
 			requireCI:    true,
 			ciMaxCycles:  2,
 			expectStatus: "pending",
+		},
+		{
+			name:           "pending with force — treats as failure",
+			ciStatus:       "pending",
+			requireCI:      true,
+			ciMaxCycles:    2,
+			force:          true,
+			expectStatus:   "failure",
+			expectFixCount: 1,
 		},
 		{
 			name:          "skipped — require_ci false",
@@ -172,7 +182,7 @@ func TestCheckCI(t *testing.T) {
 				Workers: config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"},
 			}
 
-			result, err := CheckCI(context.Background(), mock, cfg, CheckCIParams{RunID: 100})
+			result, err := CheckCI(context.Background(), mock, cfg, CheckCIParams{RunID: 100, Force: tt.force})
 			require.NoError(t, err)
 
 			if tt.expectSkipped {

--- a/internal/platform/github/checks.go
+++ b/internal/platform/github/checks.go
@@ -31,12 +31,10 @@ func (s *checkService) GetCombinedStatus(ctx context.Context, ref string) (strin
 		} else {
 			return "", fmt.Errorf("getting combined status for %s: %w", ref, err)
 		}
-	} else {
+	} else if commitStatus.GetTotalCount() > 0 {
 		// GitHub returns "pending" when there are zero commit statuses.
-		// Treat that as empty so it doesn't override check run results.
-		if commitStatus.GetTotalCount() > 0 {
-			statusState = commitStatus.GetState() // "success", "pending", "failure"
-		}
+		// Only use the state when actual statuses exist.
+		statusState = commitStatus.GetState() // "success", "pending", "failure"
 	}
 
 	// 2. Check runs

--- a/internal/platform/github/checks.go
+++ b/internal/platform/github/checks.go
@@ -32,7 +32,11 @@ func (s *checkService) GetCombinedStatus(ctx context.Context, ref string) (strin
 			return "", fmt.Errorf("getting combined status for %s: %w", ref, err)
 		}
 	} else {
-		statusState = commitStatus.GetState() // "success", "pending", "failure", or ""
+		// GitHub returns "pending" when there are zero commit statuses.
+		// Treat that as empty so it doesn't override check run results.
+		if commitStatus.GetTotalCount() > 0 {
+			statusState = commitStatus.GetState() // "success", "pending", "failure"
+		}
 	}
 
 	// 2. Check runs

--- a/internal/platform/github/checks_test.go
+++ b/internal/platform/github/checks_test.go
@@ -77,7 +77,7 @@ func TestGetCombinedStatus_CheckRunPending(t *testing.T) {
 func TestGetCombinedStatus_BothSucceed(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
-		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success")})
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("success"), TotalCount: gh.Ptr(1)})
 	})
 	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
 		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
@@ -101,7 +101,7 @@ func TestGetCombinedStatus_BothSucceed(t *testing.T) {
 func TestGetCombinedStatus_CommitStatusFailureOverridesCheckRunSuccess(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
-		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("failure")})
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("failure"), TotalCount: gh.Ptr(1)})
 	})
 	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
 		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
@@ -135,6 +135,29 @@ func TestGetCombinedStatus_NoStatusesOrChecks(t *testing.T) {
 	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
 	require.NoError(t, err)
 	assert.Equal(t, "success", status)
+}
+
+func TestGetCombinedStatus_ZeroStatusesWithFailedCheckRuns(t *testing.T) {
+	// Repos using only GitHub Actions CI have zero commit statuses (returns
+	// "pending" from the status API). Failed check runs should still be detected.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/status", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.CombinedStatus{State: gh.Ptr("pending"), TotalCount: gh.Ptr(0)})
+	})
+	mux.HandleFunc("GET /repos/test-org/test-repo/commits/main/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(gh.ListCheckRunsResults{
+			Total: gh.Ptr(2),
+			CheckRuns: []*gh.CheckRun{
+				{Name: gh.Ptr("Lint"), Status: gh.Ptr("completed"), Conclusion: gh.Ptr("success")},
+				{Name: gh.Ptr("Tests"), Status: gh.Ptr("completed"), Conclusion: gh.Ptr("failure")},
+			},
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+	status, err := client.Checks().GetCombinedStatus(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "failure", status)
 }
 
 func TestGetCombinedStatus_CheckRunCancelled(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Bug 1**: `GetCombinedStatus` returned "pending" for repos using only GitHub Actions CI (zero commit statuses). GitHub returns `state: "pending"` with `total_count: 0` when no commit statuses exist. This "pending" was overriding failed check run results in the combine logic. Fixed by ignoring the status API state when `total_count` is 0.
- **Bug 2**: `/herd fix-ci` returned "CI is pending — re-ran failed checks" without creating fix workers. Now it sets `Force: true` to bypass the pending early-return and dispatch fix workers regardless.

## Test plan
- [x] `TestGetCombinedStatus_ZeroStatusesWithFailedCheckRuns` — zero commit statuses + failed check runs returns "failure"
- [x] `TestCheckCI/pending_with_force_—_treats_as_failure` — force flag bypasses pending status
- [x] All existing combined status and CI tests pass
- [x] Full test suite passes