### PR TITLE
Add live progress comments on issues during worker execution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ workers:
   max_concurrent: 3              # max simultaneous worker Actions
   runner_label: "herd-worker"    # GitHub runner label for worker jobs
   timeout_minutes: 30            # max time per worker run
+  progress_interval_seconds: 30  # post progress updates to issue (0 = disabled)
 
 integrator:
   strategy: "squash"             # squash | rebase | merge

--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -138,6 +138,10 @@ The Integrator removes the `.herd/progress/` directory during consolidation
 do not appear in the final batch PR. For backward compatibility, legacy
 `WORKER_PROGRESS.md` files at the repo root are also removed.
 
+#### Live Progress Updates
+
+While the agent is working, the worker posts a progress comment on the issue and updates it periodically with the contents of the `.herd/progress/<issue-number>.md` file. This provides live visibility into what the agent has completed and what remains. The update interval is configurable via `workers.progress_interval_seconds` (default: 30 seconds, set to 0 to disable). When the worker finishes, the progress comment is updated one final time and kept on the issue for history.
+
 #### Retry Resume
 
 When a worker is re-dispatched for a previously timed-out task, it checks

--- a/internal/cli/batch_test.go
+++ b/internal/cli/batch_test.go
@@ -254,6 +254,12 @@ func (m *mockBatchCancelIssueService) RemoveLabels(_ context.Context, number int
 func (m *mockBatchCancelIssueService) AddComment(_ context.Context, _ int, _ string) error {
 	return nil
 }
+func (m *mockBatchCancelIssueService) AddCommentReturningID(_ context.Context, _ int, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *mockBatchCancelIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 func (m *mockBatchCancelIssueService) DeleteComment(_ context.Context, _ int64) error { return nil }
 func (m *mockBatchCancelIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return nil, nil

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -153,6 +153,7 @@ func flattenConfig(cfg *config.Config) []keyValue {
 	kvs = append(kvs, keyValue{"workers.max_concurrent", itoa(cfg.Workers.MaxConcurrent)})
 	kvs = append(kvs, keyValue{"workers.runner_label", cfg.Workers.RunnerLabel})
 	kvs = append(kvs, keyValue{"workers.timeout_minutes", itoa(cfg.Workers.TimeoutMinutes)})
+	kvs = append(kvs, keyValue{"workers.progress_interval_seconds", itoa(cfg.Workers.ProgressIntervalSeconds)})
 	kvs = append(kvs, keyValue{"integrator.strategy", cfg.Integrator.Strategy})
 	kvs = append(kvs, keyValue{"integrator.on_conflict", cfg.Integrator.OnConflict})
 	kvs = append(kvs, keyValue{"integrator.max_conflict_resolution_attempts", itoa(cfg.Integrator.MaxConflictResolutionAttempts)})

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -218,7 +218,11 @@ func (m *mockDispatchIssueService) RemoveLabels(_ context.Context, number int, l
 	return nil
 }
 func (m *mockDispatchIssueService) AddComment(_ context.Context, _ int, _ string) error { return nil }
-func (m *mockDispatchIssueService) DeleteComment(_ context.Context, _ int64) error       { return nil }
+func (m *mockDispatchIssueService) AddCommentReturningID(_ context.Context, _ int, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *mockDispatchIssueService) UpdateComment(_ context.Context, _ int64, _ string) error { return nil }
+func (m *mockDispatchIssueService) DeleteComment(_ context.Context, _ int64) error           { return nil }
 func (m *mockDispatchIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return nil, nil
 }

--- a/internal/cli/integrator_test.go
+++ b/internal/cli/integrator_test.go
@@ -313,6 +313,12 @@ func (m *mockCommentIssueService) AddComment(_ context.Context, number int, body
 	m.addedBody = body
 	return m.addCommentErr
 }
+func (m *mockCommentIssueService) AddCommentReturningID(_ context.Context, _ int, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *mockCommentIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 
 // mockFailurePlatform implements platform.Platform for testing failure comment helpers.
 type mockFailurePlatform struct {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -134,8 +134,12 @@ func (m *mockStatusIssueService) Update(_ context.Context, _ int, _ platform.Iss
 }
 func (m *mockStatusIssueService) AddLabels(_ context.Context, _ int, _ []string) error    { return nil }
 func (m *mockStatusIssueService) RemoveLabels(_ context.Context, _ int, _ []string) error { return nil }
-func (m *mockStatusIssueService) AddComment(_ context.Context, _ int, _ string) error     { return nil }
-func (m *mockStatusIssueService) DeleteComment(_ context.Context, _ int64) error          { return nil }
+func (m *mockStatusIssueService) AddComment(_ context.Context, _ int, _ string) error { return nil }
+func (m *mockStatusIssueService) AddCommentReturningID(_ context.Context, _ int, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *mockStatusIssueService) UpdateComment(_ context.Context, _ int64, _ string) error { return nil }
+func (m *mockStatusIssueService) DeleteComment(_ context.Context, _ int64) error           { return nil }
 func (m *mockStatusIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return nil, nil
 }

--- a/internal/commands/handlers_test.go
+++ b/internal/commands/handlers_test.go
@@ -94,6 +94,12 @@ func (m *testIssueService) RemoveLabels(_ context.Context, number int, labels []
 	return nil
 }
 func (m *testIssueService) AddComment(_ context.Context, _ int, _ string) error  { return nil }
+func (m *testIssueService) AddCommentReturningID(_ context.Context, _ int, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *testIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 func (m *testIssueService) DeleteComment(_ context.Context, _ int64) error       { return nil }
 func (m *testIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return m.listCommentsResult, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,9 +34,10 @@ type Agent struct {
 }
 
 type Workers struct {
-	MaxConcurrent  int    `yaml:"max_concurrent"`
-	RunnerLabel    string `yaml:"runner_label"`
-	TimeoutMinutes int    `yaml:"timeout_minutes"`
+	MaxConcurrent          int    `yaml:"max_concurrent"`
+	RunnerLabel            string `yaml:"runner_label"`
+	TimeoutMinutes         int    `yaml:"timeout_minutes"`
+	ProgressIntervalSeconds int   `yaml:"progress_interval_seconds"` // how often to post progress updates (0 = disabled)
 }
 
 type Integrator struct {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -11,9 +11,10 @@ func Default() *Config {
 			Provider: "claude",
 		},
 		Workers: Workers{
-			MaxConcurrent:  3,
-			RunnerLabel:    "herd-worker",
-			TimeoutMinutes: 30,
+			MaxConcurrent:          3,
+			RunnerLabel:            "herd-worker",
+			TimeoutMinutes:         30,
+			ProgressIntervalSeconds: 30,
 		},
 		Integrator: Integrator{
 			Strategy:                      "squash",

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -96,6 +96,12 @@ func (m *mockIssueService) AddComment(_ context.Context, number int, body string
 	m.comments[number] = append(m.comments[number], body)
 	return nil
 }
+func (m *mockIssueService) AddCommentReturningID(_ context.Context, _ int, body string) (int64, error) {
+	return 0, nil
+}
+func (m *mockIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 func (m *mockIssueService) DeleteComment(_ context.Context, _ int64) error { return nil }
 func (m *mockIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return m.listCommentsResult, nil

--- a/internal/monitor/patrol_test.go
+++ b/internal/monitor/patrol_test.go
@@ -132,6 +132,12 @@ func (m *mockIssueService) AddComment(_ context.Context, number int, body string
 	}
 	return nil
 }
+func (m *mockIssueService) AddCommentReturningID(_ context.Context, _ int, body string) (int64, error) {
+	return 0, nil
+}
+func (m *mockIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 func (m *mockIssueService) DeleteComment(_ context.Context, commentID int64) error {
 	m.deletedComments = append(m.deletedComments, commentID)
 	return nil

--- a/internal/orchestration_test.go
+++ b/internal/orchestration_test.go
@@ -155,6 +155,12 @@ func (s *statefulIssueService) AddComment(_ context.Context, number int, body st
 	s.comments[number] = append(s.comments[number], body)
 	return nil
 }
+func (s *statefulIssueService) AddCommentReturningID(_ context.Context, _ int, body string) (int64, error) {
+	return 0, nil
+}
+func (s *statefulIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 func (s *statefulIssueService) DeleteComment(_ context.Context, _ int64) error { return nil }
 func (s *statefulIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return nil, nil

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -321,6 +321,12 @@ func (m *mockIssueService) AddComment(_ context.Context, _ int, body string) err
 	m.comments = append(m.comments, body)
 	return nil
 }
+func (m *mockIssueService) AddCommentReturningID(_ context.Context, _ int, body string) (int64, error) {
+	return 0, nil
+}
+func (m *mockIssueService) UpdateComment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
 func (m *mockIssueService) DeleteComment(_ context.Context, _ int64) error { return nil }
 func (m *mockIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return nil, nil

--- a/internal/platform/github/issues.go
+++ b/internal/platform/github/issues.go
@@ -118,10 +118,24 @@ func (s *issueService) RemoveLabels(ctx context.Context, number int, labels []st
 }
 
 func (s *issueService) AddComment(ctx context.Context, number int, body string) error {
+	_, err := s.AddCommentReturningID(ctx, number, body)
+	return err
+}
+
+func (s *issueService) AddCommentReturningID(ctx context.Context, number int, body string) (int64, error) {
 	comment := &gh.IssueComment{Body: gh.Ptr(body)}
-	_, _, err := s.c.gh.Issues.CreateComment(ctx, s.c.owner, s.c.repo, number, comment)
+	created, _, err := s.c.gh.Issues.CreateComment(ctx, s.c.owner, s.c.repo, number, comment)
 	if err != nil {
-		return fmt.Errorf("adding comment to issue #%d: %w", number, err)
+		return 0, fmt.Errorf("adding comment to issue #%d: %w", number, err)
+	}
+	return created.GetID(), nil
+}
+
+func (s *issueService) UpdateComment(ctx context.Context, commentID int64, body string) error {
+	comment := &gh.IssueComment{Body: gh.Ptr(body)}
+	_, _, err := s.c.gh.Issues.EditComment(ctx, s.c.owner, s.c.repo, commentID, comment)
+	if err != nil {
+		return fmt.Errorf("updating comment %d: %w", commentID, err)
 	}
 	return nil
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -25,6 +25,8 @@ type IssueService interface {
 	AddLabels(ctx context.Context, number int, labels []string) error
 	RemoveLabels(ctx context.Context, number int, labels []string) error
 	AddComment(ctx context.Context, number int, body string) error
+	AddCommentReturningID(ctx context.Context, number int, body string) (int64, error)
+	UpdateComment(ctx context.Context, commentID int64, body string) error
 	DeleteComment(ctx context.Context, commentID int64) error
 	ListComments(ctx context.Context, number int) ([]*Comment, error)
 	CreateCommentReaction(ctx context.Context, commentID int64, reaction string) error

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -231,6 +231,11 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 			Body:        issueBody,
 		}
 
+		// Start progress poster — updates a comment on the issue periodically
+		// with the contents of the progress file.
+		progressDone := make(chan struct{})
+		go postProgressUpdates(ctx, p, params.IssueNumber, params.RepoRoot, cfg.Workers.ProgressIntervalSeconds, progressDone)
+
 		// Use a timeout for agent execution so the worker has time to push
 		// whatever work was done if the agent hangs after completing its task.
 		agentTimeout := time.Duration(cfg.Workers.TimeoutMinutes)*time.Minute - 5*time.Minute
@@ -240,6 +245,7 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 		agentCtx, agentCancel := context.WithTimeout(ctx, agentTimeout)
 		agentResult, err := ag.Execute(agentCtx, taskSpec, execOpts)
 		agentCancel()
+		close(progressDone)
 
 		if err != nil {
 			// If the agent timed out, check if work was done — if so, continue to push
@@ -518,6 +524,56 @@ func truncateOutput(s string, max int) string {
 // is done. It looks for .herd/progress/<issueNumber>.md first, then falls back
 // to WORKER_PROGRESS.md. Returns true if a progress file exists, has at least
 // one checkbox, and all checkboxes are checked.
+// postProgressUpdates polls the progress file and posts/updates a comment on
+// the issue with the current contents. Stops when done is closed.
+func postProgressUpdates(ctx context.Context, p platform.Platform, issueNumber int, repoRoot string, intervalSeconds int, done <-chan struct{}) {
+	if intervalSeconds <= 0 {
+		<-done
+		return
+	}
+
+	progressFile := filepath.Join(repoRoot, ".herd", "progress", fmt.Sprintf("%d.md", issueNumber))
+	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
+	defer ticker.Stop()
+
+	var commentID int64
+	var lastContent string
+
+	for {
+		select {
+		case <-done:
+			// Post final update with completed state
+			if content, err := os.ReadFile(progressFile); err == nil && string(content) != lastContent {
+				body := "📋 **Worker Progress** _(final)_\n\n" + string(content)
+				if commentID != 0 {
+					_ = p.Issues().UpdateComment(ctx, commentID, body)
+				}
+			} else if commentID != 0 && lastContent != "" {
+				body := "📋 **Worker Progress** _(final)_\n\n" + lastContent
+				_ = p.Issues().UpdateComment(ctx, commentID, body)
+			}
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			content, err := os.ReadFile(progressFile)
+			if err != nil || string(content) == lastContent {
+				continue
+			}
+			lastContent = string(content)
+			body := fmt.Sprintf("📋 **Worker Progress** _(updating every %ds)_\n\n%s", intervalSeconds, lastContent)
+			if commentID == 0 {
+				id, createErr := p.Issues().AddCommentReturningID(ctx, issueNumber, body)
+				if createErr == nil {
+					commentID = id
+				}
+			} else {
+				_ = p.Issues().UpdateComment(ctx, commentID, body)
+			}
+		}
+	}
+}
+
 func checkProgressComplete(repoRoot string, issueNumber int) bool {
 	paths := []string{
 		filepath.Join(repoRoot, ".herd", "progress", fmt.Sprintf("%d.md", issueNumber)),

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -86,12 +86,15 @@ func (m *mockPlatform) Repository() platform.RepositoryService     { return m.re
 func (m *mockPlatform) Checks() platform.CheckService             { return nil }
 
 type mockIssueService struct {
-	getResult      *platform.Issue
-	getErr         error
-	addedLabels    []string
-	removedLabels  []string
-	comments       []string
-	updatedIssues  map[int]platform.IssueUpdate
+	getResult         *platform.Issue
+	getErr            error
+	addedLabels       []string
+	removedLabels     []string
+	comments          []string
+	updatedIssues     map[int]platform.IssueUpdate
+	nextCommentID     int64
+	updatedComments   map[int64]string
+	deletedComments   []int64
 }
 
 func (m *mockIssueService) Create(_ context.Context, _, _ string, _ []string, _ *int) (*platform.Issue, error) {
@@ -121,7 +124,22 @@ func (m *mockIssueService) AddComment(_ context.Context, _ int, body string) err
 	m.comments = append(m.comments, body)
 	return nil
 }
-func (m *mockIssueService) DeleteComment(_ context.Context, _ int64) error { return nil }
+func (m *mockIssueService) AddCommentReturningID(_ context.Context, _ int, body string) (int64, error) {
+	m.comments = append(m.comments, body)
+	m.nextCommentID++
+	return m.nextCommentID, nil
+}
+func (m *mockIssueService) UpdateComment(_ context.Context, commentID int64, body string) error {
+	if m.updatedComments == nil {
+		m.updatedComments = make(map[int64]string)
+	}
+	m.updatedComments[commentID] = body
+	return nil
+}
+func (m *mockIssueService) DeleteComment(_ context.Context, commentID int64) error {
+	m.deletedComments = append(m.deletedComments, commentID)
+	return nil
+}
 func (m *mockIssueService) ListComments(_ context.Context, _ int) ([]*platform.Comment, error) {
 	return nil, nil
 }
@@ -463,6 +481,89 @@ func (h *hangingAgent) Execute(ctx context.Context, _ agent.TaskSpec, _ agent.Ex
 }
 func (h *hangingAgent) Review(_ context.Context, _ string, _ agent.ReviewOptions) (*agent.ReviewResult, error) {
 	return nil, nil
+}
+
+func TestPostProgressUpdates_PostsAndUpdates(t *testing.T) {
+	dir := t.TempDir()
+	progressDir := filepath.Join(dir, ".herd", "progress")
+	require.NoError(t, os.MkdirAll(progressDir, 0755))
+	progressFile := filepath.Join(progressDir, "42.md")
+
+	issueSvc := &mockIssueService{}
+	mock := &mockPlatform{issues: issueSvc}
+
+	done := make(chan struct{})
+	go postProgressUpdates(context.Background(), mock, 42, dir, 1, done)
+
+	// Write initial progress
+	require.NoError(t, os.WriteFile(progressFile, []byte("- [x] Step 1\n- [ ] Step 2\n"), 0644))
+	time.Sleep(1500 * time.Millisecond)
+
+	// Should have created a comment
+	require.NotEmpty(t, issueSvc.comments, "should have posted progress comment")
+	assert.Contains(t, issueSvc.comments[0], "Step 1")
+
+	// Update progress
+	require.NoError(t, os.WriteFile(progressFile, []byte("- [x] Step 1\n- [x] Step 2\n"), 0644))
+	time.Sleep(1500 * time.Millisecond)
+
+	// Should have updated the comment
+	require.NotEmpty(t, issueSvc.updatedComments, "should have updated progress comment")
+	var lastUpdate string
+	for _, body := range issueSvc.updatedComments {
+		lastUpdate = body
+	}
+	assert.Contains(t, lastUpdate, "Step 2")
+
+	close(done)
+	time.Sleep(100 * time.Millisecond)
+
+	// Should NOT have deleted the comment (kept for history)
+	assert.Empty(t, issueSvc.deletedComments, "progress comment should be kept for history")
+}
+
+func TestPostProgressUpdates_DisabledWhenZero(t *testing.T) {
+	issueSvc := &mockIssueService{}
+	mock := &mockPlatform{issues: issueSvc}
+
+	done := make(chan struct{})
+	go postProgressUpdates(context.Background(), mock, 42, t.TempDir(), 0, done)
+
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Empty(t, issueSvc.comments, "should not post when interval is 0")
+}
+
+func TestPostProgressUpdates_FinalUpdateOnDone(t *testing.T) {
+	dir := t.TempDir()
+	progressDir := filepath.Join(dir, ".herd", "progress")
+	require.NoError(t, os.MkdirAll(progressDir, 0755))
+	progressFile := filepath.Join(progressDir, "42.md")
+
+	issueSvc := &mockIssueService{}
+	mock := &mockPlatform{issues: issueSvc}
+
+	done := make(chan struct{})
+	go postProgressUpdates(context.Background(), mock, 42, dir, 1, done)
+
+	// Write progress and wait for first post
+	require.NoError(t, os.WriteFile(progressFile, []byte("- [x] Step 1\n"), 0644))
+	time.Sleep(1500 * time.Millisecond)
+
+	// Update progress file and immediately close — should get final update
+	require.NoError(t, os.WriteFile(progressFile, []byte("- [x] Step 1\n- [x] Step 2\n"), 0644))
+	close(done)
+	time.Sleep(100 * time.Millisecond)
+
+	// Final update should contain "(final)" marker
+	var finalBody string
+	for _, body := range issueSvc.updatedComments {
+		finalBody = body
+	}
+	assert.Contains(t, finalBody, "final")
+	assert.Contains(t, finalBody, "Step 2")
 }
 
 func TestExec_AgentTimeoutWithCompletedWork(t *testing.T) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -86,6 +87,7 @@ func (m *mockPlatform) Repository() platform.RepositoryService     { return m.re
 func (m *mockPlatform) Checks() platform.CheckService             { return nil }
 
 type mockIssueService struct {
+	mu                sync.Mutex
 	getResult         *platform.Issue
 	getErr            error
 	addedLabels       []string
@@ -125,11 +127,15 @@ func (m *mockIssueService) AddComment(_ context.Context, _ int, body string) err
 	return nil
 }
 func (m *mockIssueService) AddCommentReturningID(_ context.Context, _ int, body string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.comments = append(m.comments, body)
 	m.nextCommentID++
 	return m.nextCommentID, nil
 }
 func (m *mockIssueService) UpdateComment(_ context.Context, commentID int64, body string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.updatedComments == nil {
 		m.updatedComments = make(map[int64]string)
 	}
@@ -137,6 +143,8 @@ func (m *mockIssueService) UpdateComment(_ context.Context, commentID int64, bod
 	return nil
 }
 func (m *mockIssueService) DeleteComment(_ context.Context, commentID int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.deletedComments = append(m.deletedComments, commentID)
 	return nil
 }
@@ -500,26 +508,32 @@ func TestPostProgressUpdates_PostsAndUpdates(t *testing.T) {
 	time.Sleep(1500 * time.Millisecond)
 
 	// Should have created a comment
+	issueSvc.mu.Lock()
 	require.NotEmpty(t, issueSvc.comments, "should have posted progress comment")
 	assert.Contains(t, issueSvc.comments[0], "Step 1")
+	issueSvc.mu.Unlock()
 
 	// Update progress
 	require.NoError(t, os.WriteFile(progressFile, []byte("- [x] Step 1\n- [x] Step 2\n"), 0644))
 	time.Sleep(1500 * time.Millisecond)
 
 	// Should have updated the comment
+	issueSvc.mu.Lock()
 	require.NotEmpty(t, issueSvc.updatedComments, "should have updated progress comment")
 	var lastUpdate string
 	for _, body := range issueSvc.updatedComments {
 		lastUpdate = body
 	}
+	issueSvc.mu.Unlock()
 	assert.Contains(t, lastUpdate, "Step 2")
 
 	close(done)
 	time.Sleep(100 * time.Millisecond)
 
 	// Should NOT have deleted the comment (kept for history)
+	issueSvc.mu.Lock()
 	assert.Empty(t, issueSvc.deletedComments, "progress comment should be kept for history")
+	issueSvc.mu.Unlock()
 }
 
 func TestPostProgressUpdates_DisabledWhenZero(t *testing.T) {
@@ -558,10 +572,12 @@ func TestPostProgressUpdates_FinalUpdateOnDone(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Final update should contain "(final)" marker
+	issueSvc.mu.Lock()
 	var finalBody string
 	for _, body := range issueSvc.updatedComments {
 		finalBody = body
 	}
+	issueSvc.mu.Unlock()
 	assert.Contains(t, finalBody, "final")
 	assert.Contains(t, finalBody, "Step 2")
 }


### PR DESCRIPTION
## Summary
- Workers now post a progress comment on the issue and update it periodically with the contents of `.herd/progress/<N>.md`
- Configurable interval via `workers.progress_interval_seconds` (default: 30s, 0 to disable)
- Comment is kept on the issue for history (marked as "final" when worker completes)
- Added `AddCommentReturningID` and `UpdateComment` to the `IssueService` interface

## Test plan
- [x] `TestPostProgressUpdates_PostsAndUpdates` — creates comment on first progress, updates on change
- [x] `TestPostProgressUpdates_DisabledWhenZero` — no comments when interval is 0
- [x] `TestPostProgressUpdates_FinalUpdateOnDone` — final update posted with "(final)" marker, comment not deleted
- [x] All tests pass, lint clean