### PR TITLE
Simplify progress comment label

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -561,7 +561,7 @@ func postProgressUpdates(ctx context.Context, p platform.Platform, issueNumber i
 				continue
 			}
 			lastContent = string(content)
-			body := fmt.Sprintf("📋 **Worker Progress** _(updating every %ds)_\n\n%s", intervalSeconds, lastContent)
+			body := "📋 **Worker Progress** _(live)_\n\n" + lastContent
 			if commentID == 0 {
 				id, createErr := p.Issues().AddCommentReturningID(ctx, issueNumber, body)
 				if createErr == nil {


### PR DESCRIPTION
## Summary
- Changed progress comment label from "updating every 30s" to "live" — it only updates when the file changes, not on a fixed interval

## Test plan
- [x] One-line change, no logic affected