### PR TITLE
Retry original failed issue after conflict resolution

### DIFF
--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -230,6 +230,9 @@ func Consolidate(ctx context.Context, p platform.Platform, g *git.Git, cfg *conf
 	// Close stale conflict/rebase issues whose worker branches no longer exist
 	closeStaleConflictIssues(ctx, p, issue.Milestone)
 
+	// If this was a conflict resolution issue, retry the original failed issue
+	retryConflictOriginIssues(ctx, p, cfg, issue, batchBranch)
+
 	// Delete worker branch
 	if err := p.Repository().DeleteBranch(ctx, workerBranch); err != nil {
 		// Non-fatal — log but don't fail
@@ -572,6 +575,60 @@ func removeBatchPRRebasePending(ctx context.Context, p platform.Platform, batchB
 		return
 	}
 	_ = p.Issues().RemoveLabels(ctx, prs[0].Number, []string{issues.RebasePending})
+}
+
+// retryConflictOriginIssues checks if the consolidated issue was a conflict
+// resolution issue, and if so, re-dispatches the original failed issue whose
+// worker branch caused the conflict.
+func retryConflictOriginIssues(ctx context.Context, p platform.Platform, cfg *config.Config, issue *platform.Issue, batchBranch string) {
+	parsed, err := issues.ParseBody(issue.Body)
+	if err != nil || !parsed.FrontMatter.ConflictResolution {
+		return
+	}
+
+	defaultBranch, err := p.Repository().GetDefaultBranch(ctx)
+	if err != nil {
+		fmt.Printf("Warning: failed to get default branch for conflict retry: %v\n", err)
+		return
+	}
+
+	for _, branch := range parsed.FrontMatter.ConflictingBranches {
+		if !strings.HasPrefix(branch, "herd/worker/") {
+			continue
+		}
+		// Extract issue number from branch name: herd/worker/471-slug → 471
+		parts := strings.SplitN(strings.TrimPrefix(branch, "herd/worker/"), "-", 2)
+		if len(parts) == 0 {
+			continue
+		}
+		origNum, parseErr := strconv.Atoi(parts[0])
+		if parseErr != nil {
+			continue
+		}
+
+		origIssue, getErr := p.Issues().Get(ctx, origNum)
+		if getErr != nil {
+			continue
+		}
+		if issues.StatusLabel(origIssue.Labels) != issues.StatusFailed {
+			continue
+		}
+
+		fmt.Printf("Conflict resolved — re-dispatching original issue #%d.\n", origNum)
+		_ = p.Issues().RemoveLabels(ctx, origNum, []string{issues.StatusFailed})
+		_ = p.Issues().AddLabels(ctx, origNum, []string{issues.StatusInProgress})
+		_, dispatchErr := p.Workflows().Dispatch(ctx, "herd-worker.yml", defaultBranch, map[string]string{
+			"issue_number":    fmt.Sprintf("%d", origNum),
+			"batch_branch":    batchBranch,
+			"timeout_minutes": fmt.Sprintf("%d", cfg.Workers.TimeoutMinutes),
+			"runner_label":    cfg.Workers.RunnerLabel,
+		})
+		if dispatchErr != nil {
+			_ = p.Issues().RemoveLabels(ctx, origNum, []string{issues.StatusInProgress})
+			_ = p.Issues().AddLabels(ctx, origNum, []string{issues.StatusFailed})
+			fmt.Printf("Warning: failed to re-dispatch #%d after conflict resolution: %v\n", origNum, dispatchErr)
+		}
+	}
 }
 
 func closeStaleConflictIssues(ctx context.Context, p platform.Platform, ms *platform.Milestone) {

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -2277,3 +2277,90 @@ func TestDispatchRebaseConflictWorker_TaskDescriptionContainsGitInstructions(t *
 	assert.Contains(t, body, "conflict markers")
 	assert.Contains(t, body, "git rebase --continue")
 }
+
+func TestRetryConflictOriginIssues(t *testing.T) {
+	// Issue 50 is a conflict resolution issue referencing worker branch for issue 42
+	conflictIssue := &platform.Issue{
+		Number: 50, Title: "Resolve conflict: #42",
+		Body: "---\nherd:\n  version: 1\n  batch: 1\n  type: fix\n  conflict_resolution: true\n  conflicting_branches:\n    - herd/worker/42-some-task\n    - herd/batch/1-batch\n---\n\n## Task\nResolve conflict\n",
+	}
+	// Issue 42 is the original failed issue
+	origIssue := &platform.Issue{
+		Number: 42, Title: "Some task",
+		Labels:    []string{issues.StatusFailed},
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = origIssue
+
+	wf := &mockWorkflowService{
+		listResult: []*platform.Run{},
+	}
+
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		workflows: wf,
+		repo:      &mockRepoService{defaultBranch: "main"},
+	}
+
+	cfg := &config.Config{Workers: config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"}}
+
+	retryConflictOriginIssues(context.Background(), mock, cfg, conflictIssue, "herd/batch/1-batch")
+
+	// Original issue should be relabeled in-progress and dispatched
+	assert.Contains(t, issueSvc.removedLabels[42], issues.StatusFailed)
+	assert.Contains(t, issueSvc.addedLabels[42], issues.StatusInProgress)
+	assert.Len(t, wf.dispatched, 1)
+}
+
+func TestRetryConflictOriginIssues_SkipsNonFailed(t *testing.T) {
+	conflictIssue := &platform.Issue{
+		Number: 50, Title: "Resolve conflict: #42",
+		Body: "---\nherd:\n  version: 1\n  batch: 1\n  type: fix\n  conflict_resolution: true\n  conflicting_branches:\n    - herd/worker/42-some-task\n    - herd/batch/1-batch\n---\n\n## Task\nResolve conflict\n",
+	}
+	origIssue := &platform.Issue{
+		Number: 42, Title: "Some task",
+		Labels:    []string{issues.StatusDone}, // already done, should skip
+		Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+	}
+
+	issueSvc := newMockIssueService()
+	issueSvc.getResult[42] = origIssue
+
+	wf := &mockWorkflowService{}
+
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		workflows: wf,
+		repo:      &mockRepoService{defaultBranch: "main"},
+	}
+
+	cfg := &config.Config{Workers: config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"}}
+
+	retryConflictOriginIssues(context.Background(), mock, cfg, conflictIssue, "herd/batch/1-batch")
+
+	// Should NOT dispatch — issue is not failed
+	assert.Empty(t, wf.dispatched)
+}
+
+func TestRetryConflictOriginIssues_SkipsNonConflictIssue(t *testing.T) {
+	regularIssue := &platform.Issue{
+		Number: 50, Title: "Regular task",
+		Body: "---\nherd:\n  version: 1\n  batch: 1\n---\n\n## Task\nDo something\n",
+	}
+
+	wf := &mockWorkflowService{}
+	mock := &mockPlatform{
+		issues:    newMockIssueService(),
+		workflows: wf,
+		repo:      &mockRepoService{defaultBranch: "main"},
+	}
+
+	cfg := &config.Config{}
+
+	retryConflictOriginIssues(context.Background(), mock, cfg, regularIssue, "herd/batch/1-batch")
+
+	// Should NOT dispatch — not a conflict resolution issue
+	assert.Empty(t, wf.dispatched)
+}


### PR DESCRIPTION
## Summary
- When a worker branch has a merge conflict during consolidation, a conflict resolution issue is created and the original issue is marked failed
- After the conflict resolution worker completes, the original issue was never retried — it stayed failed indefinitely
- Now `retryConflictOriginIssues` extracts the original issue number from the conflict resolution issue's `conflicting_branches` frontmatter and re-dispatches it if still failed

## Test plan
- [x] `TestRetryConflictOriginIssues` — re-dispatches original failed issue after conflict resolution
- [x] `TestRetryConflictOriginIssues_SkipsNonFailed` — skips if original issue is already done
- [x] `TestRetryConflictOriginIssues_SkipsNonConflictIssue` — no-op for regular issues
- [x] Full test suite passes with `-race`