### PR TITLE
Count only worker runs for concurrency limit

### DIFF
--- a/internal/integrator/integrator.go
+++ b/internal/integrator/integrator.go
@@ -372,7 +372,7 @@ func Advance(ctx context.Context, p platform.Platform, g *git.Git, cfg *config.C
 // dispatchReadyIssues dispatches ready/blocked issues from a tier, respecting
 // concurrency limits. Returns the number of issues dispatched.
 func dispatchReadyIssues(ctx context.Context, p platform.Platform, cfg *config.Config, tierIssues []int, allIssues []*platform.Issue, batchBranch string) (int, error) {
-	activeRuns, err := p.Workflows().ListRuns(ctx, platform.RunFilters{Status: "in_progress"})
+	activeRuns, err := p.Workflows().ListRuns(ctx, platform.RunFilters{Status: "in_progress", WorkflowFileName: "herd-worker.yml"})
 	if err != nil {
 		return 0, fmt.Errorf("counting active workers: %w", err)
 	}

--- a/internal/integrator/integrator_test.go
+++ b/internal/integrator/integrator_test.go
@@ -167,10 +167,11 @@ func (m *mockPRService) Close(_ context.Context, _ int) error {
 }
 
 type mockWorkflowService struct {
-	runs         map[int64]*platform.Run
-	listResult   []*platform.Run
-	dispatched   []map[string]string
-	onDispatch   func() // optional; called before recording each dispatch
+	runs              map[int64]*platform.Run
+	listResult        []*platform.Run
+	dispatched        []map[string]string
+	onDispatch        func() // optional; called before recording each dispatch
+	lastListRunFilter platform.RunFilters
 }
 
 func (m *mockWorkflowService) GetWorkflow(_ context.Context, _ string) (int64, error) { return 0, nil }
@@ -187,7 +188,8 @@ func (m *mockWorkflowService) GetRun(_ context.Context, id int64) (*platform.Run
 	}
 	return nil, nil
 }
-func (m *mockWorkflowService) ListRuns(_ context.Context, _ platform.RunFilters) ([]*platform.Run, error) {
+func (m *mockWorkflowService) ListRuns(_ context.Context, filters platform.RunFilters) ([]*platform.Run, error) {
+	m.lastListRunFilter = filters
 	return m.listResult, nil
 }
 func (m *mockWorkflowService) CancelRun(_ context.Context, _ int64) error { return nil }
@@ -573,6 +575,8 @@ func TestAdvance_TierComplete(t *testing.T) {
 	assert.Contains(t, issueSvc.removedLabels[11], issues.StatusBlocked)
 	assert.Contains(t, issueSvc.addedLabels[11], issues.StatusInProgress)
 	assert.Len(t, wf.dispatched, 1)
+	// Concurrency check should filter by worker workflow only
+	assert.Equal(t, "herd-worker.yml", wf.lastListRunFilter.WorkflowFileName)
 }
 
 func TestAdvance_DispatchesReadyIssues(t *testing.T) {

--- a/internal/platform/github/workflows.go
+++ b/internal/platform/github/workflows.go
@@ -64,7 +64,15 @@ func (s *workflowService) ListRuns(ctx context.Context, filters platform.RunFilt
 
 	var result []*platform.Run
 
-	if filters.WorkflowID != 0 {
+	if filters.WorkflowFileName != "" {
+		runs, _, err := s.c.gh.Actions.ListWorkflowRunsByFileName(ctx, s.c.owner, s.c.repo, filters.WorkflowFileName, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing workflow runs by file: %w", err)
+		}
+		for _, r := range runs.WorkflowRuns {
+			result = append(result, mapRun(r))
+		}
+	} else if filters.WorkflowID != 0 {
 		runs, _, err := s.c.gh.Actions.ListWorkflowRunsByID(ctx, s.c.owner, s.c.repo, filters.WorkflowID, opts)
 		if err != nil {
 			return nil, fmt.Errorf("listing workflow runs: %w", err)

--- a/internal/platform/github/workflows_test.go
+++ b/internal/platform/github/workflows_test.go
@@ -92,6 +92,30 @@ func TestWorkflowServiceListRuns(t *testing.T) {
 	assert.Equal(t, int64(100), runs[0].ID)
 }
 
+func TestWorkflowServiceListRuns_ByWorkflowFileName(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/test-org/test-repo/actions/workflows/herd-worker.yml/runs", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "in_progress", r.URL.Query().Get("status"))
+		resp := gh.WorkflowRuns{
+			TotalCount: gh.Ptr(1),
+			WorkflowRuns: []*gh.WorkflowRun{
+				{ID: gh.Ptr(int64(200)), Status: gh.Ptr("in_progress")},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	client, _ := newTestClient(t, mux)
+	runs, err := client.Workflows().ListRuns(context.Background(), platform.RunFilters{
+		Status:           "in_progress",
+		WorkflowFileName: "herd-worker.yml",
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, runs, 1)
+	assert.Equal(t, int64(200), runs[0].ID)
+}
+
 func TestWorkflowServiceGetRun_ParsesRunName(t *testing.T) {
 	ts := gh.Timestamp{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}
 	mux := http.NewServeMux()

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -119,9 +119,10 @@ type PRFilters struct {
 }
 
 type RunFilters struct {
-	WorkflowID int64
-	Status     string // "queued", "in_progress", "completed"
-	Branch     string
+	WorkflowID       int64
+	WorkflowFileName string // e.g. "herd-worker.yml" — used to filter by workflow file
+	Status           string // "queued", "in_progress", "completed"
+	Branch           string
 }
 
 type MilestoneUpdate struct {


### PR DESCRIPTION
## Summary
- `dispatchReadyIssues` was counting all in-progress workflow runs (including integrator, monitor) against `max_concurrent`, leaving fewer worker slots than configured
- Now filters by `herd-worker.yml` so only actual worker runs count
- Added `WorkflowFileName` filter to `RunFilters` and `ListRuns` implementation

## Test plan
- [x] `TestWorkflowServiceListRuns_ByWorkflowFileName` — verifies API call uses correct workflow file path
- [x] `TestAdvance_TierComplete` — verifies concurrency check uses `herd-worker.yml` filter
- [x] Full test suite passes with `-race`