### PR TITLE
Fix docker compose build failing to resolve herd-runner-base

### DIFF
--- a/docker-compose.herd.yml
+++ b/docker-compose.herd.yml
@@ -16,6 +16,8 @@ services:
   worker:
     build:
       dockerfile: Dockerfile.herd_runner
+      additional_contexts:
+        herd-runner-base: service:herd-runner-base
     depends_on:
       herd-runner-base:
         condition: service_completed_successfully

--- a/internal/cli/runner/docker-compose.herd.yml.tmpl
+++ b/internal/cli/runner/docker-compose.herd.yml.tmpl
@@ -16,6 +16,8 @@ services:
   worker:
     build:
       dockerfile: Dockerfile.herd_runner
+      additional_contexts:
+        herd-runner-base: service:herd-runner-base
     depends_on:
       herd-runner-base:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary
- `docker compose -f docker-compose.herd.yml build` failed because BuildKit tried to pull `herd-runner-base` from Docker Hub instead of building it from the local service
- Added `additional_contexts: herd-runner-base: service:herd-runner-base` to the worker build config, enabling single-command builds
- Updated both the repo's own compose file and the `herd init` template

## Test plan
- [x] Tested on Docker Compose v2.40.3 (TrueNAS server) — builds successfully
- [ ] Test on Docker Compose v5+ (local machine)