### PR TITLE
Skip CI fix dispatch when a fix worker is already in progress

### DIFF
--- a/internal/integrator/ci.go
+++ b/internal/integrator/ci.go
@@ -101,11 +101,19 @@ func CheckCI(ctx context.Context, p platform.Platform, cfg *config.Config, param
 		return nil, fmt.Errorf("listing milestone issues: %w", err)
 	}
 
+	// Skip if a CI fix worker is already in progress
 	currentCycle := 0
 	for _, iss := range allIssues {
 		parsed, parseErr := issues.ParseBody(iss.Body)
 		if parseErr != nil {
 			continue
+		}
+		if parsed.FrontMatter.CIFixCycle > 0 {
+			status := issues.StatusLabel(iss.Labels)
+			if status == issues.StatusInProgress || status == issues.StatusReady {
+				fmt.Printf("Skipping CI fix: fix issue #%d is still %s\n", iss.Number, status)
+				return &CheckCIResult{Status: "failure"}, nil
+			}
 		}
 		if parsed.FrontMatter.CIFixCycle > currentCycle {
 			currentCycle = parsed.FrontMatter.CIFixCycle

--- a/internal/integrator/ci_test.go
+++ b/internal/integrator/ci_test.go
@@ -378,3 +378,48 @@ func TestCheckCI_FixIssueOnFirstFailure(t *testing.T) {
 	assert.Equal(t, 1, result.FixCycle)
 	assert.False(t, checkSvc.rerunCalled, "RerunFailedChecks must not be called")
 }
+
+func TestCheckCI_SkipsWhenCIFixInProgress(t *testing.T) {
+	issueSvc, wf, prSvc := baseCIMocks()
+	// Existing CI fix issue that's still in progress
+	issueSvc.listResult = []*platform.Issue{
+		{
+			Number: 80,
+			Labels: []string{issues.StatusInProgress},
+			Body:   "---\nherd:\n  version: 1\n  ci_fix_cycle: 1\n---\n\n## Task\nFix CI\n",
+		},
+	}
+
+	createdIssues := []*platform.Issue{}
+	mockCreate := &mockIssueServiceWithCreate{
+		mockIssueService: issueSvc,
+		onCreate: func(title, body string, labels []string, milestone *int) (*platform.Issue, error) {
+			iss := &platform.Issue{Number: 99, Title: title}
+			createdIssues = append(createdIssues, iss)
+			return iss, nil
+		},
+	}
+
+	checkSvc := &mockCheckService{status: "failure"}
+	mock := &mockPlatformWithChecks{
+		mockPlatform: &mockPlatform{
+			issues:     mockCreate,
+			prs:        prSvc,
+			workflows:  wf,
+			repo:       &mockRepoService{defaultBranch: "main"},
+			milestones: &mockMilestoneService{},
+		},
+		checks: checkSvc,
+	}
+
+	cfg := &config.Config{
+		Integrator: config.Integrator{RequireCI: true, CIMaxFixCycles: 0},
+		Workers:    config.Workers{TimeoutMinutes: 30, RunnerLabel: "herd-worker"},
+	}
+
+	result, err := CheckCI(context.Background(), mock, cfg, CheckCIParams{RunID: 100})
+	require.NoError(t, err)
+	assert.Equal(t, "failure", result.Status)
+	assert.Empty(t, createdIssues, "should not create fix issue when one is already in progress")
+	assert.Empty(t, wf.dispatched, "should not dispatch when fix is in progress")
+}


### PR DESCRIPTION
## Summary
- `CheckCI` was creating duplicate fix issues when triggered multiple times (e.g., manual `/herd fix-ci` while a previous fix worker was still running)
- Now checks for in-progress or ready CI fix issues before creating a new one, matching the review path's existing dedup guard

## Test plan
- [x] `TestCheckCI_SkipsWhenCIFixInProgress` — no fix issue created when one is already in-progress
- [x] Full test suite passes with `-race`, lint clean