### PR TITLE
Install HerdOS v0.7.1

### DIFF
--- a/.github/workflows/herd-worker.yml
+++ b/.github/workflows/herd-worker.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: ''
-      mode:
-        description: 'Execution mode: batch (default) or standalone'
-        required: false
-        type: string
-        default: 'batch'
       timeout_minutes:
         description: 'Max execution time'
         required: false
@@ -55,6 +50,5 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
-          HERD_WORKER_MODE: ${{ inputs.mode }}
         run: |
           herd worker exec "$ISSUE_NUMBER"


### PR DESCRIPTION
Installs HerdOS workflows and runner infrastructure at v0.7.1.

Created by `herd init`.