### PR TITLE
Point herd's own Dockerfile.herd_runner at GHCR base image

### DIFF
--- a/Dockerfile.herd_runner
+++ b/Dockerfile.herd_runner
@@ -1,7 +1,7 @@
 # HerdOS Runner — project customization
 # This file is yours to customize — herd init will never overwrite it.
 
-FROM herd-runner-base
+FROM ghcr.io/herd-os/herd-runner-base:latest
 
 USER root
 


### PR DESCRIPTION
## Summary
The "Herd Publish Runner Image" workflow failed because herd's own `Dockerfile.herd_runner` still had the pre-GHCR `FROM herd-runner-base` line. A bare image name resolves to Docker Hub (`docker.io/library/herd-runner-base`), which doesn't exist → `pull access denied`.

`Dockerfile.herd_runner` is user-owned (never overwritten by `herd init`), so the GHCR migration never updated herd's own copy.

Fixed by pointing it at `ghcr.io/herd-os/herd-runner-base:latest`. Using `:latest` (not a pinned version) so herd's own CI runner tracks the newest base without a manual bump each release.

## Test plan
- After merge to main, the `Dockerfile.herd_runner` path change triggers the Herd Publish Runner Image workflow automatically
- Verify the build resolves `ghcr.io/herd-os/herd-runner-base:latest` and pushes the customized runner image

## Note
Requires `ghcr.io/herd-os/herd-runner-base` to be **public** (or the workflow's `GITHUB_TOKEN` packages:read scope to cover it). If the package is still private from first publish, flip it to public in the GHCR UI.