### PR TITLE
Auto-publish herd-bin to AUR on release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,20 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           ./scripts/update-homebrew.sh $VERSION bin/checksums.txt
 
+      # AUR push runs inside archlinux:base-devel because makepkg --printsrcinfo
+      # is required to generate .SRCINFO and is not available on Ubuntu runners.
+      - name: Update AUR (herd-bin)
+        if: env.AUR_SSH_PRIVATE_KEY != ''
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          docker run --rm \
+            -e AUR_SSH_PRIVATE_KEY \
+            -v "$PWD:/work" -w /work \
+            archlinux:base-devel \
+            bash -c "pacman -Sy --noconfirm --needed openssh && ./scripts/update-aur.sh $VERSION bin/checksums.txt"
+
   # NOTE: The first time this package is pushed, GHCR creates it as
   # private. The herd-runner-base package must be made
   # public (one-time, manual) in the org's GHCR package settings

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,20 @@
 brew install herd-os/tap/herd
 ```
 
+## Arch Linux (AUR)
+
+```bash
+yay -S herd-bin   # or: paru -S herd-bin
+```
+
+`herd-bin` installs the pre-built linux-amd64 / linux-arm64 binary from the latest GitHub Release and tracks tagged releases automatically. Manual install (no AUR helper):
+
+```bash
+git clone https://aur.archlinux.org/herd-bin.git
+cd herd-bin
+makepkg -si
+```
+
 ## Binary Download
 
 Download the latest release for your platform from the [GitHub Releases page](https://github.com/Herd-OS/herd/releases/latest).
@@ -76,6 +90,9 @@ The check is skipped by design for development builds (`herd --version` reports 
 ```bash
 # Homebrew
 brew upgrade herd-os/tap/herd
+
+# AUR (Arch Linux)
+yay -Syu herd-bin
 
 # Binary download — same as installation, replace the existing binary
 
@@ -150,6 +167,7 @@ Builds binaries for all supported platforms, generates `checksums.txt`, and:
 - Uploads the linux-amd64 binary as a workflow artifact (`herd-linux-amd64`, retained for 1 day) so the follow-up `self-init` job can use the exact bits that were just built without racing the GitHub Release publish.
 - Publishes a GitHub Release via [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release) with all platform binaries plus `checksums.txt` attached.
 - Updates the `herd-os/homebrew-tap` formula via `scripts/update-homebrew.sh` (only if `HERD_GITHUB_TOKEN` is set).
+- Updates the `herd-bin` AUR package via `scripts/update-aur.sh` (only if `AUR_SSH_PRIVATE_KEY` is set). The step runs inside an `archlinux:base-devel` container because `makepkg --printsrcinfo` is required to regenerate `.SRCINFO` and is not available on Ubuntu runners.
 
 ### `self-init` job
 
@@ -186,3 +204,46 @@ token: ${{ secrets.HERD_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 ```
 
 Prefer `HERD_GITHUB_TOKEN` (a PAT with `contents` and `pull-requests` write) when available — PRs created by the default `GITHUB_TOKEN` do not trigger downstream workflows, which can hide CI failures on the self-init PR. The fallback to `GITHUB_TOKEN` keeps the job functional in forks or environments where the secret is not configured.
+
+### AUR (herd-bin) setup
+
+The `Update AUR (herd-bin)` step in the release job pushes a new `PKGBUILD` + `.SRCINFO` to `ssh://aur@aur.archlinux.org/herd-bin.git` on every tag. It is gated on the `AUR_SSH_PRIVATE_KEY` secret being set; if the secret is absent, the step is skipped and the release completes normally without an AUR update.
+
+**One-time setup (only needed once per maintainer / per repo):**
+
+1. Create an AUR account at https://aur.archlinux.org/register.
+2. Generate a dedicated SSH key (no passphrase if it will be stored as a GitHub Actions secret):
+
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/aur_ed25519 -N "" -C "aur-herd-bin"
+   ```
+
+3. Add the **public** key (`~/.ssh/aur_ed25519.pub`) to your AUR account at https://aur.archlinux.org/account/ → "SSH Public Key".
+4. On a local Arch box, clone the empty AUR repo, copy in a valid PKGBUILD, regenerate `.SRCINFO`, validate, and do the **initial push** (the workflow can only update an existing AUR repo, not create one):
+
+   ```bash
+   # Optional but recommended SSH config entry — keeps your GitHub keys from being offered first
+   cat >> ~/.ssh/config << 'EOF'
+   Host aur.archlinux.org
+     HostName aur.archlinux.org
+     User aur
+     IdentityFile ~/.ssh/aur_ed25519
+     IdentitiesOnly yes
+   EOF
+
+   git clone ssh://aur@aur.archlinux.org/herd-bin.git
+   cd herd-bin
+   # Copy a known-good PKGBUILD in (e.g. from a tagged release of this repo).
+   # Then:
+   makepkg --printsrcinfo > .SRCINFO
+   makepkg -si          # local install — confirms the package works end-to-end
+   git add PKGBUILD .SRCINFO
+   git commit -m "Initial import (herd-bin v<X.Y.Z>)"
+   git push
+   ```
+
+5. Add the **private** key as a GitHub Actions secret named `AUR_SSH_PRIVATE_KEY` (the entire contents of `~/.ssh/aur_ed25519`, including the `-----BEGIN OPENSSH PRIVATE KEY-----` header). From then on, every tag push triggers the workflow to regenerate the PKGBUILD with the new version + checksums, regenerate `.SRCINFO` via `makepkg --printsrcinfo`, and push to AUR as `herd-os[bot]`.
+
+**Updating the PKGBUILD template:** the AUR PKGBUILD is generated inline by `scripts/update-aur.sh`. Edits to dependencies, optdepends, or the `package()` function go there. The script must remain runnable both inside the CI container and on a maintainer's local Arch box (it detects `EUID==0` and drops to a `builder` user for `makepkg`).
+
+**Skipping AUR on a release:** unset or rename the `AUR_SSH_PRIVATE_KEY` secret temporarily. The release will still publish binaries and update Homebrew.

--- a/scripts/update-aur.sh
+++ b/scripts/update-aur.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/update-aur.sh <version> <checksums-file>
+# Example: ./scripts/update-aur.sh v0.1.0 bin/checksums.txt
+#
+# Requires:
+#   - AUR_SSH_PRIVATE_KEY env var containing an ed25519 private key registered
+#     to a maintainer account on aur.archlinux.org with push access to the
+#     `herd-bin` package.
+#   - `makepkg` available on PATH (run on Arch Linux locally, or inside an
+#     archlinux:base-devel container in CI).
+#   - `git` and `ssh` available on PATH.
+
+VERSION="${1:?Usage: $0 <version> <checksums-file>}"
+CHECKSUMS_FILE="${2:?Usage: $0 <version> <checksums-file>}"
+
+# Strip leading 'v' for the PKGBUILD version
+PKG_VERSION="${VERSION#v}"
+
+AUR_PACKAGE="herd-bin"
+AUR_REMOTE="ssh://aur@aur.archlinux.org/${AUR_PACKAGE}.git"
+
+# Parse checksums
+get_sha256() {
+	local binary="$1"
+	grep " ${binary}\$" "${CHECKSUMS_FILE}" | awk '{print $1}'
+}
+
+SHA_LINUX_AMD64=$(get_sha256 "herd-linux-amd64")
+SHA_LINUX_ARM64=$(get_sha256 "herd-linux-arm64")
+
+for var in SHA_LINUX_AMD64 SHA_LINUX_ARM64; do
+	if [[ -z "${!var}" ]]; then
+		echo "ERROR: Could not find checksum for ${var}" >&2
+		exit 1
+	fi
+done
+
+if [[ -z "${AUR_SSH_PRIVATE_KEY:-}" ]]; then
+	echo "ERROR: AUR_SSH_PRIVATE_KEY env var is empty" >&2
+	exit 1
+fi
+
+# Set up ephemeral SSH key + known_hosts
+SSH_DIR=$(mktemp -d)
+trap 'rm -rf "${SSH_DIR}"' EXIT
+
+printf '%s\n' "${AUR_SSH_PRIVATE_KEY}" > "${SSH_DIR}/id_aur"
+chmod 600 "${SSH_DIR}/id_aur"
+
+# AUR's published SSH host key (ed25519). See https://aur.archlinux.org/
+cat > "${SSH_DIR}/known_hosts" << 'KNOWN'
+aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
+KNOWN
+
+export GIT_SSH_COMMAND="ssh -i ${SSH_DIR}/id_aur -o IdentitiesOnly=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts"
+
+# Clone AUR repo
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${SSH_DIR}" "${TMPDIR}"' EXIT
+
+git clone "${AUR_REMOTE}" "${TMPDIR}/${AUR_PACKAGE}"
+cd "${TMPDIR}/${AUR_PACKAGE}"
+
+# AUR only accepts pushes to `master`. Fresh clones of a not-yet-created
+# pkgbase may end up on whatever the local init.defaultBranch is (often `main`),
+# so normalize unconditionally — no-op if we're already on master.
+git checkout -B master
+
+# Generate PKGBUILD
+cat > PKGBUILD << PKGBUILD
+# Maintainer: JF Turcot <jf.turcot@gmail.com>
+pkgname=herd-bin
+_pkgname=herd
+pkgver=${PKG_VERSION}
+pkgrel=1
+pkgdesc="GitHub-native orchestration platform for AI coding agents"
+arch=('x86_64' 'aarch64')
+url="https://github.com/Herd-OS/herd"
+license=('Apache-2.0')
+depends=('git' 'github-cli')
+optdepends=('docker: self-hosted worker runner containers'
+            'docker-compose: legacy docker-compose-based runner deployment')
+provides=('herd')
+conflicts=('herd' 'herd-git')
+source_x86_64=("herd-\$pkgver-x86_64::https://github.com/Herd-OS/herd/releases/download/v\$pkgver/herd-linux-amd64")
+source_aarch64=("herd-\$pkgver-aarch64::https://github.com/Herd-OS/herd/releases/download/v\$pkgver/herd-linux-arm64")
+sha256sums_x86_64=('${SHA_LINUX_AMD64}')
+sha256sums_aarch64=('${SHA_LINUX_ARM64}')
+
+package() {
+  install -Dm755 "herd-\$pkgver-\$CARCH" "\$pkgdir/usr/bin/herd"
+}
+PKGBUILD
+
+# Generate .SRCINFO (makepkg refuses to run as root; if EUID == 0, drop to a builder user)
+if [[ ${EUID} -eq 0 ]]; then
+	if ! id -u builder >/dev/null 2>&1; then
+		useradd -m builder
+	fi
+	chown -R builder .
+	runuser -u builder -- makepkg --printsrcinfo > .SRCINFO
+	chown -R root:root .
+	# Cloned worktree may still look "dubious" to git after the chown round-trip
+	git config --global --add safe.directory "$PWD"
+else
+	makepkg --printsrcinfo > .SRCINFO
+fi
+
+# Commit and push
+git add PKGBUILD .SRCINFO
+if git diff --cached --quiet; then
+	echo "No changes to commit"
+	exit 0
+fi
+
+git config user.name "herd-os[bot]"
+git config user.email "herd-os[bot]@users.noreply.github.com"
+git commit -m "Update to ${VERSION}"
+git push
+echo "Updated AUR ${AUR_PACKAGE} to ${VERSION}"


### PR DESCRIPTION
## Summary
- Adds `scripts/update-aur.sh` (mirrors `scripts/update-homebrew.sh`): renders the `herd-bin` PKGBUILD inline, regenerates `.SRCINFO`, and pushes to `ssh://aur@aur.archlinux.org/herd-bin.git`. Detects `EUID==0` and drops to a `builder` user for `makepkg --printsrcinfo` (which refuses root), then restores ownership for the git push.
- Adds an `Update AUR (herd-bin)` step to the `release` job. Runs inside `archlinux:base-devel` because `makepkg` is not available on Ubuntu runners. Gated on the `AUR_SSH_PRIVATE_KEY` secret — absent secret skips the step cleanly.
- Documents the user-facing install (`yay -S herd-bin`), the upgrade path, and a maintainer "AUR (herd-bin) setup" subsection in `docs/installation.md` covering one-time AUR account + ed25519 key + initial push.

## Test plan
- [x] PKGBUILD validated locally on Arch: `makepkg --printsrcinfo` parses; `makepkg -d --noconfirm` built `herd-bin 0.8.2-1.pkg.tar.zst` end-to-end
- [x] Initial AUR push completed manually; `herd-bin` is live at https://aur.archlinux.org/packages/herd-bin
- [ ] After merge, add `AUR_SSH_PRIVATE_KEY` to repo secrets (full contents of the maintainer's `~/.ssh/aur_ed25519`, header+footer included)
- [ ] On the next tag, confirm the `Update AUR (herd-bin)` step succeeds and `herd-bin` on AUR moves to the new version