### PR TITLE
[herd] Fix worker retry loop stuck on validation failure (progress-file short-circuit) (2 tasks)

### DIFF
--- a/.herd/progress/656.md
+++ b/.herd/progress/656.md
@@ -1,8 +1,0 @@
-- [x] Update Pre-Push Validation section (execution.md) with Validation Marker subsection (marker + errors files, worker-written)
-- [x] Update progress-file / resume section to distinguish progress file (agent) vs validation marker (worker)
-- [x] Update Integrator removal note to mention marker/errors files cleaned up
-- [x] Update Retry Resume skip-agent fast path to require BOTH progress complete AND validation marker; describe stale-progress retry prompt
-- [x] Correct failure-modes table row
-- [x] Update getting-started.md /herd retry description (no-op clarification)
-- [x] grep docs/ for stale statements — all in execution.md and corrected
-- [x] go build/vet/test pass; herd init --check passes; diff is docs-only

--- a/.herd/progress/656.md
+++ b/.herd/progress/656.md
@@ -1,0 +1,8 @@
+- [x] Update Pre-Push Validation section (execution.md) with Validation Marker subsection (marker + errors files, worker-written)
+- [x] Update progress-file / resume section to distinguish progress file (agent) vs validation marker (worker)
+- [x] Update Integrator removal note to mention marker/errors files cleaned up
+- [x] Update Retry Resume skip-agent fast path to require BOTH progress complete AND validation marker; describe stale-progress retry prompt
+- [x] Correct failure-modes table row
+- [x] Update getting-started.md /herd retry description (no-op clarification)
+- [x] grep docs/ for stale statements — all in execution.md and corrected
+- [x] go build/vet/test pass; herd init --check passes; diff is docs-only

--- a/docs/design/execution.md
+++ b/docs/design/execution.md
@@ -96,6 +96,30 @@ Before pushing changes, workers run validation commands:
 
 If validation fails, the agent is re-invoked with the error output. If it fails again after retry, the worker is marked as failed.
 
+#### Validation Marker
+
+The worker code (not the agent) records the outcome of pre-push validation in two
+files under `.herd/progress/`, both keyed by issue number and both committed so
+they survive across worker invocations:
+
+- `.herd/progress/<N>.validation` — an empty marker file written **only** after
+  `runValidation` reports that every command passed. Its presence means
+  "validation actually passed for this issue." The marker is removed at the start
+  of every agent invocation and on any validation failure, so a stale marker from
+  a previous pass can never be carried over.
+- `.herd/progress/<N>.validation.errors` — the combined output of the failing
+  validation commands, written whenever validation fails (and removed once
+  validation passes). The output is truncated to ~16 KB, keeping the tail since
+  the most relevant errors appear last. On the next attempt the worker reads this
+  file and injects it into the agent prompt under a
+  `## Previous attempt's validation failed with:` heading.
+
+These files are written, removed, and committed by the worker framework. They are
+distinct from the agent-written `.herd/progress/<N>.md` checklist described under
+[Incremental Push and Progress Tracking](#incremental-push-and-progress-tracking):
+the progress file reflects only what the *agent* claims it finished, while the
+validation marker reflects whether validation *actually* passed.
+
 Validation is Go-specific — it only runs when a `go.mod` file exists in the repository root.
 
 ### Worker Reports
@@ -137,6 +161,13 @@ writes to `.herd/progress/17.md`), preventing merge conflicts between parallel
 workers. This file contains a checklist of completed and remaining items. On
 retry, the agent reads the existing file to understand what was already done.
 
+The `.herd/progress/<issue-number>.md` file is **agent-written** and means only
+"the agent claims its checklist is done." It is not proof that the work is
+correct — for that, the worker relies on the separate, worker-written
+`.herd/progress/<issue-number>.validation` marker (see
+[Validation Marker](#validation-marker)), which is present only when pre-push
+validation actually passed.
+
 Example `.herd/progress/17.md`:
 ```
 - [x] Create auth model in internal/auth/model.go
@@ -147,7 +178,10 @@ Example `.herd/progress/17.md`:
 
 The Integrator removes the `.herd/progress/` directory during consolidation
 (after merging the worker branch into the batch branch) so progress files
-do not appear in the final batch PR. For backward compatibility, legacy
+do not appear in the final batch PR. This removes everything under that
+directory, including the worker-written `.herd/progress/<issue-number>.validation`
+marker and `.herd/progress/<issue-number>.validation.errors` files, so none of
+them leak into the final batch PR either. For backward compatibility, legacy
 `WORKER_PROGRESS.md` files at the repo root are also removed.
 
 #### Live Progress Updates
@@ -173,15 +207,28 @@ the current batch branch. A warning is logged:
 branch." The previous partial work is lost, but this is preferable to crashing
 and leaving the issue stuck as failed.
 
-If the resumed worker branch's progress file (`.herd/progress/<issue-number>.md`
-or legacy `WORKER_PROGRESS.md`) shows all items checked off — every checkbox is
-`- [x]` and none are `- [ ]` — the worker skips agent invocation entirely. This
-handles the case where a previous attempt completed all work and pushed it, but
-timed out before finishing validation or posting the worker report. The worker
-still runs pre-push validation (build, test, vet, lint), posts the worker report,
-pushes the branch, and labels the issue as done. If the progress file shows
-incomplete work, the normal retry flow continues (the agent is launched with the
-progress file as context to continue where the previous attempt stopped).
+The skip-agent fast path requires **both** signals: the progress file
+(`.herd/progress/<issue-number>.md` or legacy `WORKER_PROGRESS.md`) must show all
+items checked off — every checkbox is `- [x]` and none are `- [ ]` — **and** the
+worker-written `.herd/progress/<issue-number>.validation` marker must be present.
+When both hold, the worker skips agent invocation entirely. This handles the case
+where a previous attempt completed all work, passed validation, and pushed it, but
+timed out before posting the worker report. The worker still runs pre-push
+validation (build, test, vet, lint), posts the worker report, pushes the branch,
+and labels the issue as done.
+
+When the progress file is complete but the validation marker is **absent** — the
+previous attempt's validation failed, so the marker was removed and never
+re-created — the worker does **not** take the fast path. Instead it re-invokes the
+agent and injects the saved `.herd/progress/<issue-number>.validation.errors` into
+the prompt under `## Previous attempt's validation failed with:`. In this case the
+worker uses a retry prompt variant that explicitly tells the agent the progress
+file is **stale** and must not be honored: the validation errors are the only task,
+and the agent must not skip work just because the checklist looks complete.
+
+If the progress file shows incomplete work, the normal retry flow continues (the
+agent is launched with the progress file as context to continue where the previous
+attempt stopped).
 
 ### Concurrency
 
@@ -193,7 +240,7 @@ GitHub Actions limits.
 
 | Failure | Response |
 |---------|----------|
-| Worker crashes mid-task | Partial work preserved via incremental pushes; Action fails; worker triggers Monitor for immediate response; Monitor re-dispatches; retried worker resumes from existing branch and `.herd/progress/<issue-number>.md`; if the batch branch has diverged and merge conflicts, the worker falls back to a fresh branch (partial work is lost); if the progress file shows all work complete, the retry skips agent invocation and proceeds directly to validation and reporting |
+| Worker crashes mid-task | Partial work preserved via incremental pushes; Action fails; worker triggers Monitor for immediate response; Monitor re-dispatches; retried worker resumes from existing branch and `.herd/progress/<issue-number>.md`; if the batch branch has diverged and merge conflicts, the worker falls back to a fresh branch (partial work is lost); the retry skips agent invocation and proceeds directly to validation and reporting only when the progress file shows all work complete **and** the `.herd/progress/<issue-number>.validation` marker is present — otherwise the agent is re-invoked with the saved validation errors |
 | Worker produces bad code | Integrator dispatches fix workers up to the CI fix cap; at cap, reverts consolidation and labels issue failed |
 | Worker can't complete task | Labels issue failed, triggers Monitor; Monitor comments diagnostics and @mentions notify_users |
 | Work already done (no-op) | Posts a Worker Report comment ("No changes were needed"), labels issue done without creating a branch; Integrator advances normally |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -316,6 +316,8 @@ When you post a command, HerdOS reacts with 👀 to acknowledge it, executes the
 /herd integrate
 ```
 
+`/herd retry` always re-runs the worker, and it is never a no-op just because a previous attempt's progress checklist looks complete. If the previous attempt finished its work but failed pre-push validation, the retry re-invokes the agent with the saved validation errors (the agent is told the progress file is stale) rather than skipping straight to reporting — the agent is skipped only when both the progress file is complete and the worker's validation marker is present. See [design/execution.md → Retry Resume](design/execution.md#retry-resume) for details.
+
 When the integrator fails during any step (consolidation, CI check, advancement, or review), it posts a comment on the relevant issue or batch PR with the error details and a reminder to retry with `/herd integrate`.
 
 Quotes around the prompt text are optional. You can paste error logs, JSON snippets, or any text directly after the command — everything after the command name (including subsequent lines) is treated as the prompt. The quoted format (`/herd fix "description"`) is also still supported.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -106,6 +106,9 @@ func (g *Git) DeleteLocalBranch(name string) error {
 	return g.run("branch", "-D", name)
 }
 
+// Add stages a file (or path) into the git index.
+func (g *Git) Add(path string) error { return g.run("add", "--", path) }
+
 // Rm removes a file from the git index and working tree.
 func (g *Git) Rm(path string) error {
 	return g.run("rm", path)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -260,14 +260,19 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 		// If we are resuming a previous attempt whose validation failed (progress
 		// complete but no marker), inject the saved validation errors so the agent
 		// knows what was broken instead of re-validating the same failing code.
+		// In that case we also render the retry prompt variant so the agent is told
+		// the progress file is stale and must not be honored — otherwise the all-`[x]`
+		// checklist could lead it to conclude there is nothing left to do.
+		resumeAfterValidationFailure := false
 		if remoteBranchErr == nil {
 			if prevErrs, ok := readValidationErrors(params.RepoRoot, params.IssueNumber); ok && checkProgressComplete(params.RepoRoot, params.IssueNumber) {
 				issueBody += fmt.Sprintf("\n\n## Previous attempt's validation failed with:\n\n```\n%s\n```\n", prevErrs)
+				resumeAfterValidationFailure = true
 			}
 		}
 
 		// Build system prompt only when agent will actually run
-		systemPrompt, err := renderWorkerPrompt(issue.Title, issueBody, params.IssueNumber, workerBranch, params.RepoRoot, cfg, false)
+		systemPrompt, err := renderWorkerPrompt(issue.Title, issueBody, params.IssueNumber, workerBranch, params.RepoRoot, cfg, resumeAfterValidationFailure)
 		if err != nil {
 			return nil, fmt.Errorf("rendering worker prompt: %w", err)
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -761,10 +761,23 @@ func removeValidationErrors(repoRoot string, issueNumber int) error {
 // files so they survive across worker invocations. Best-effort: logs but does
 // not fail the worker if git operations error (e.g. nothing to commit).
 func commitValidationStatus(g *git.Git, repoRoot string, issueNumber int, message string) {
-	_ = g.Add(validationMarkerPath(repoRoot, issueNumber))
-	_ = g.Add(validationErrorsPath(repoRoot, issueNumber))
+	for _, p := range []string{
+		validationMarkerPath(repoRoot, issueNumber),
+		validationErrorsPath(repoRoot, issueNumber),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			_ = g.Add(p)
+		} else if os.IsNotExist(err) {
+			// Stage the deletion if the file used to be tracked; ignore "did not match" for never-tracked paths.
+			_ = g.Rm(p)
+		}
+	}
 	if err := g.Commit(message); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: committing validation status for #%d: %v\n", issueNumber, err)
+		// Empty commit (nothing to stage) is the common case after the very first marker write; do not log on that.
+		if !strings.Contains(err.Error(), "nothing to commit") &&
+			!strings.Contains(err.Error(), "no changes added") {
+			fmt.Fprintf(os.Stderr, "warning: committing validation status for #%d: %v\n", issueNumber, err)
+		}
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -101,7 +101,12 @@ const workerPromptTemplate = `You are a HerdOS worker executing a task.
   code that doesn't exist and can't be inferred).
 - If you cannot complete the task after exhausting alternatives,
   exit with a non-zero status and include the reason in your output.
-## Incremental Progress
+{{if .Retry}}## Validation Failed — Stale Progress
+
+- Pre-push validation FAILED on the code currently in the worktree. The validation errors are in the Task body above and are the ONLY thing you must fix.
+- A ` + "`.herd/progress/{{.IssueNumber}}.md`" + ` file may exist from the previous attempt. It is STALE — do NOT honor it, do NOT treat its checked items as proof the work is correct, and do NOT skip work because of it.
+- Make the minimal changes needed to make validation pass. Commit and push to ` + "`{{.WorkerBranch}}`" + `.
+{{else}}## Incremental Progress
 
 - Your branch is ` + "`{{.WorkerBranch}}`" + `. After completing work on each file or
   logical unit, run ` + "`git push origin {{.WorkerBranch}}`" + ` to save your progress
@@ -110,10 +115,13 @@ const workerPromptTemplate = `You are a HerdOS worker executing a task.
   Update it before each push with a checklist of what you have completed
   and what remains. Format: completed items checked (` + "`- [x]`" + `), remaining items
   unchecked (` + "`- [ ]`" + `).
+- The progress file alone no longer causes the worker to skip re-running the
+  agent: the worker now also requires that pre-push validation passed last time.
+  Keep writing it as before — it is still used to resume a timed-out attempt.
 - If .herd/progress/{{.IssueNumber}}.md already exists when you start (from a previous
   timed-out attempt), read it to understand what was already done and continue
   from where it left off. Do not redo completed work.
-{{if .CoAuthorTrailer}}- Add the following trailer to every commit message (on its own line after a blank line):
+{{end}}{{if .CoAuthorTrailer}}- Add the following trailer to every commit message (on its own line after a blank line):
   {{.CoAuthorTrailer}}
 {{end}}{{if .RoleInstructions}}
 ## Project-Specific Instructions
@@ -128,6 +136,7 @@ type promptData struct {
 	RoleInstructions string
 	CoAuthorTrailer  string
 	IsFixIssue       bool
+	Retry            bool
 }
 
 // Exec runs the full worker lifecycle: reads the issue, creates a worker branch,
@@ -221,10 +230,14 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 		}
 	}
 
-	// Check if previous attempt already completed all work
+	// Check if previous attempt already completed all work AND validation passed.
+	// Both the progress file and the worker-written validation marker are required:
+	// a completed progress file alone is no longer trusted as proof the work is
+	// correct, otherwise a broken-but-"complete" attempt would short-circuit every
+	// retry with the same failing code.
 	skipAgent := false
-	if remoteBranchErr == nil && checkProgressComplete(params.RepoRoot, params.IssueNumber) {
-		fmt.Printf("Progress file shows all work complete for issue #%d — skipping agent execution.\n", params.IssueNumber)
+	if remoteBranchErr == nil && checkProgressComplete(params.RepoRoot, params.IssueNumber) && checkValidationPassed(params.RepoRoot, params.IssueNumber) {
+		fmt.Printf("Progress file shows all work complete and validation passed for issue #%d — skipping agent execution.\n", params.IssueNumber)
 		skipAgent = true
 	}
 
@@ -242,10 +255,19 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 
 	rawSummary := ""
 	if skipAgent {
-		rawSummary = "Skipped — previous attempt completed all work (detected via progress file)."
+		rawSummary = "Skipped — previous attempt completed all work and validation passed (detected via progress file and validation marker)."
 	} else {
+		// If we are resuming a previous attempt whose validation failed (progress
+		// complete but no marker), inject the saved validation errors so the agent
+		// knows what was broken instead of re-validating the same failing code.
+		if remoteBranchErr == nil {
+			if prevErrs, ok := readValidationErrors(params.RepoRoot, params.IssueNumber); ok && checkProgressComplete(params.RepoRoot, params.IssueNumber) {
+				issueBody += fmt.Sprintf("\n\n## Previous attempt's validation failed with:\n\n```\n%s\n```\n", prevErrs)
+			}
+		}
+
 		// Build system prompt only when agent will actually run
-		systemPrompt, err := renderWorkerPrompt(issue.Title, issueBody, params.IssueNumber, workerBranch, params.RepoRoot, cfg)
+		systemPrompt, err := renderWorkerPrompt(issue.Title, issueBody, params.IssueNumber, workerBranch, params.RepoRoot, cfg, false)
 		if err != nil {
 			return nil, fmt.Errorf("rendering worker prompt: %w", err)
 		}
@@ -274,6 +296,9 @@ func Exec(ctx context.Context, p platform.Platform, ag agent.Agent, cfg *config.
 		if agentTimeout < 5*time.Minute {
 			agentTimeout = 5 * time.Minute
 		}
+		// Remove any stale validation marker so a previous pass cannot carry over;
+		// the marker is re-created only after runValidation reports allPassed().
+		_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
 		agentCtx, agentCancel := context.WithTimeout(ctx, agentTimeout)
 		agentResult, err := ag.Execute(agentCtx, taskSpec, execOpts)
 		agentCancel()
@@ -350,8 +375,15 @@ pushWork:
 	if !validation.allPassed() {
 		fmt.Printf("Validation failed, re-invoking agent to fix:\n%s\n", validation.Errors)
 
-		// Build system prompt for the retry agent invocation
-		retryPrompt, rpErr := renderWorkerPrompt(issue.Title, issueBody, params.IssueNumber, workerBranch, params.RepoRoot, cfg)
+		// Persist the failure so a subsequent outer retry has context, and clear
+		// the marker so the failing code cannot be treated as validated.
+		_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
+		_ = writeValidationErrors(params.RepoRoot, params.IssueNumber, validation.Errors)
+		commitValidationStatus(g, params.RepoRoot, params.IssueNumber, fmt.Sprintf("Update validation status for #%d", params.IssueNumber))
+
+		// Build system prompt for the retry agent invocation. Use the retry
+		// variant so the agent does NOT honor the stale progress file.
+		retryPrompt, rpErr := renderWorkerPrompt(issue.Title, issueBody, params.IssueNumber, workerBranch, params.RepoRoot, cfg, true)
 		if rpErr != nil {
 			return nil, fmt.Errorf("rendering worker prompt for retry: %w", rpErr)
 		}
@@ -367,6 +399,8 @@ pushWork:
 			Title:       "Fix validation failures",
 			Body:        fmt.Sprintf("The following validation commands failed after your changes. Please fix all errors:\n\n```\n%s\n```\n\nDo not add new features — only fix the validation errors.", validation.Errors),
 		}
+		// Remove any stale marker right before the retry invocation too.
+		_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
 		retryResult, retryErr := ag.Execute(ctx, retrySpec, retryExecOpts)
 		if retryErr != nil {
 			_ = p.Issues().AddComment(ctx, params.IssueNumber,
@@ -381,6 +415,11 @@ pushWork:
 		// Re-run validation
 		validation = runValidation(ctx, params.RepoRoot)
 		if !validation.allPassed() {
+			// Persist the failure so the next outer attempt has context.
+			_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
+			_ = writeValidationErrors(params.RepoRoot, params.IssueNumber, validation.Errors)
+			commitValidationStatus(g, params.RepoRoot, params.IssueNumber, fmt.Sprintf("Update validation status for #%d", params.IssueNumber))
+
 			// Post report with failure info, then fail
 			report := buildWorkerReport(g, batchBranch, rawSummary, validation)
 			report += "\n\n⚠️ Validation failed after retry. Worker marked as failed."
@@ -391,6 +430,14 @@ pushWork:
 			return nil, fmt.Errorf("validation failed after retry: %s", validation.Errors)
 		}
 	}
+
+	// Validation passed — record the marker and clear any saved errors so the
+	// next worker invocation can safely skip the agent.
+	if err = writeValidationMarker(params.RepoRoot, params.IssueNumber); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: writing validation marker for #%d: %v\n", params.IssueNumber, err)
+	}
+	_ = removeValidationErrors(params.RepoRoot, params.IssueNumber)
+	commitValidationStatus(g, params.RepoRoot, params.IssueNumber, fmt.Sprintf("Update validation status for #%d", params.IssueNumber))
 
 	// Force push worker branch — previous failed attempts may have left
 	// stale commits on the remote branch that would cause a non-fast-forward rejection.
@@ -634,7 +681,89 @@ func isAllChecked(content string) bool {
 	return checked > 0
 }
 
-func renderWorkerPrompt(title, body string, issueNumber int, workerBranch string, repoRoot string, cfg *config.Config) (string, error) {
+// validationMarkerPath returns the path to the worker-written marker that
+// records that pre-push validation passed for this issue.
+func validationMarkerPath(repoRoot string, issueNumber int) string {
+	return filepath.Join(repoRoot, ".herd", "progress", fmt.Sprintf("%d.validation", issueNumber))
+}
+
+// validationErrorsPath returns the path to the saved validation error output
+// from the previous failed attempt.
+func validationErrorsPath(repoRoot string, issueNumber int) string {
+	return filepath.Join(repoRoot, ".herd", "progress", fmt.Sprintf("%d.validation.errors", issueNumber))
+}
+
+// writeValidationMarker writes an empty marker file recording that validation
+// passed. Creates the .herd/progress directory if missing.
+func writeValidationMarker(repoRoot string, issueNumber int) error {
+	path := validationMarkerPath(repoRoot, issueNumber)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte{}, 0o644)
+}
+
+// removeValidationMarker removes the validation marker. Missing file is not an error.
+func removeValidationMarker(repoRoot string, issueNumber int) error {
+	err := os.Remove(validationMarkerPath(repoRoot, issueNumber))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// checkValidationPassed reports whether the validation marker exists.
+func checkValidationPassed(repoRoot string, issueNumber int) bool {
+	_, err := os.Stat(validationMarkerPath(repoRoot, issueNumber))
+	return err == nil
+}
+
+const validationErrorsMaxBytes = 16 * 1024
+
+// writeValidationErrors saves the failing validation output (truncated to
+// validationErrorsMaxBytes, keeping the TAIL since the most relevant errors are
+// usually last) so the next attempt can pass it into the agent prompt.
+func writeValidationErrors(repoRoot string, issueNumber int, errs string) error {
+	path := validationErrorsPath(repoRoot, issueNumber)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if len(errs) > validationErrorsMaxBytes {
+		errs = "...(truncated)...\n" + errs[len(errs)-validationErrorsMaxBytes:]
+	}
+	return os.WriteFile(path, []byte(errs), 0o644)
+}
+
+// readValidationErrors returns the saved validation errors and true if present.
+func readValidationErrors(repoRoot string, issueNumber int) (string, bool) {
+	data, err := os.ReadFile(validationErrorsPath(repoRoot, issueNumber))
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// removeValidationErrors removes the saved validation errors file. Missing file is not an error.
+func removeValidationErrors(repoRoot string, issueNumber int) error {
+	err := os.Remove(validationErrorsPath(repoRoot, issueNumber))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// commitValidationStatus stages and commits the validation marker / errors
+// files so they survive across worker invocations. Best-effort: logs but does
+// not fail the worker if git operations error (e.g. nothing to commit).
+func commitValidationStatus(g *git.Git, repoRoot string, issueNumber int, message string) {
+	_ = g.Add(validationMarkerPath(repoRoot, issueNumber))
+	_ = g.Add(validationErrorsPath(repoRoot, issueNumber))
+	if err := g.Commit(message); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: committing validation status for #%d: %v\n", issueNumber, err)
+	}
+}
+
+func renderWorkerPrompt(title, body string, issueNumber int, workerBranch string, repoRoot string, cfg *config.Config, retry bool) (string, error) {
 	tmpl, err := template.New("worker").Parse(workerPromptTemplate)
 	if err != nil {
 		return "", fmt.Errorf("parsing worker prompt template: %w", err)
@@ -651,6 +780,7 @@ func renderWorkerPrompt(title, body string, issueNumber int, workerBranch string
 		IssueNumber:  issueNumber,
 		WorkerBranch: workerBranch,
 		IsFixIssue:   isFixIssue,
+		Retry:        retry,
 	}
 
 	if cfg.PullRequests.CoAuthorEmail != "" {
@@ -730,7 +860,12 @@ Your commits are pushed directly to the target branch — there is no consolidat
   code that doesn't exist and can't be inferred).
 - If you cannot complete the task after exhausting alternatives,
   exit with a non-zero status and include the reason in your output.
-## Incremental Progress
+{{if .Retry}}## Validation Failed — Stale Progress
+
+- Pre-push validation FAILED on the code currently in the worktree. The validation errors are in the Task body above and are the ONLY thing you must fix.
+- A ` + "`.herd/progress/{{.IssueNumber}}.md`" + ` file may exist from the previous attempt. It is STALE — do NOT honor it, do NOT treat its checked items as proof the work is correct, and do NOT skip work because of it.
+- Make the minimal changes needed to make validation pass. Commit and push to ` + "`{{.TargetBranch}}`" + `.
+{{else}}## Incremental Progress
 
 - Your branch is ` + "`{{.TargetBranch}}`" + `. After completing work on each file or
   logical unit, run ` + "`git push origin {{.TargetBranch}}`" + ` to save your progress
@@ -739,10 +874,13 @@ Your commits are pushed directly to the target branch — there is no consolidat
   Update it before each push with a checklist of what you have completed
   and what remains. Format: completed items checked (` + "`- [x]`" + `), remaining items
   unchecked (` + "`- [ ]`" + `).
+- The progress file alone no longer causes the worker to skip re-running the
+  agent: the worker now also requires that pre-push validation passed last time.
+  Keep writing it as before — it is still used to resume a timed-out attempt.
 - If .herd/progress/{{.IssueNumber}}.md already exists when you start (from a previous
   timed-out attempt), read it to understand what was already done and continue
   from where it left off. Do not redo completed work.
-{{if .CoAuthorTrailer}}- Add the following trailer to every commit message (on its own line after a blank line):
+{{end}}{{if .CoAuthorTrailer}}- Add the following trailer to every commit message (on its own line after a blank line):
   {{.CoAuthorTrailer}}
 {{end}}{{if .RoleInstructions}}
 ## Project-Specific Instructions
@@ -756,9 +894,10 @@ type standalonePromptData struct {
 	TargetBranch     string
 	RoleInstructions string
 	CoAuthorTrailer  string
+	Retry            bool
 }
 
-func renderStandalonePrompt(title, body string, issueNumber int, targetBranch, repoRoot string, cfg *config.Config) (string, error) {
+func renderStandalonePrompt(title, body string, issueNumber int, targetBranch, repoRoot string, cfg *config.Config, retry bool) (string, error) {
 	tmpl, err := template.New("worker-standalone").Parse(workerStandalonePromptTemplate)
 	if err != nil {
 		return "", fmt.Errorf("parsing standalone prompt template: %w", err)
@@ -769,6 +908,7 @@ func renderStandalonePrompt(title, body string, issueNumber int, targetBranch, r
 		Body:         body,
 		IssueNumber:  issueNumber,
 		TargetBranch: targetBranch,
+		Retry:        retry,
 	}
 
 	if cfg.PullRequests.CoAuthorEmail != "" {
@@ -830,7 +970,7 @@ func execStandalone(ctx context.Context, p platform.Platform, ag agent.Agent, cf
 		}
 	}
 
-	systemPrompt, err := renderStandalonePrompt(issue.Title, issueBody, params.IssueNumber, targetBranch, params.RepoRoot, cfg)
+	systemPrompt, err := renderStandalonePrompt(issue.Title, issueBody, params.IssueNumber, targetBranch, params.RepoRoot, cfg, false)
 	if err != nil {
 		return nil, fmt.Errorf("rendering standalone prompt: %w", err)
 	}
@@ -842,6 +982,9 @@ func execStandalone(ctx context.Context, p platform.Platform, ag agent.Agent, cf
 	if agentTimeout < 5*time.Minute {
 		agentTimeout = 5 * time.Minute
 	}
+	// Remove any stale validation marker so a previous pass cannot carry over;
+	// the marker is re-created only after runValidation reports allPassed().
+	_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
 	agentCtx, agentCancel := context.WithTimeout(ctx, agentTimeout)
 	taskSpec := agent.TaskSpec{IssueNumber: params.IssueNumber, Title: issue.Title, Body: issueBody}
 	execOpts := agent.ExecOptions{RepoRoot: params.RepoRoot, SystemPrompt: systemPrompt, MaxTurns: cfg.Agent.MaxTurns}
@@ -896,7 +1039,14 @@ func execStandalone(ctx context.Context, p platform.Platform, ag agent.Agent, cf
 	if !validation.allPassed() {
 		fmt.Printf("Validation failed, re-invoking agent to fix:\n%s\n", validation.Errors)
 
-		retryPrompt, rpErr := renderStandalonePrompt(issue.Title, issueBody, params.IssueNumber, targetBranch, params.RepoRoot, cfg)
+		// Persist the failure and clear the marker so the failing code cannot be
+		// treated as validated by a subsequent invocation.
+		_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
+		_ = writeValidationErrors(params.RepoRoot, params.IssueNumber, validation.Errors)
+		commitValidationStatus(g, params.RepoRoot, params.IssueNumber, fmt.Sprintf("Update validation status for #%d", params.IssueNumber))
+
+		// Use the retry variant so the agent does NOT honor the stale progress file.
+		retryPrompt, rpErr := renderStandalonePrompt(issue.Title, issueBody, params.IssueNumber, targetBranch, params.RepoRoot, cfg, true)
 		if rpErr != nil {
 			return nil, fmt.Errorf("rendering standalone prompt for retry: %w", rpErr)
 		}
@@ -910,6 +1060,8 @@ func execStandalone(ctx context.Context, p platform.Platform, ag agent.Agent, cf
 			Title:       "Fix validation failures",
 			Body:        fmt.Sprintf("The following validation commands failed after your changes. Please fix all errors:\n\n```\n%s\n```\n\nDo not add new features — only fix the validation errors.", validation.Errors),
 		}
+		// Remove any stale marker right before the retry invocation too.
+		_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
 		retryResult, retryErr := ag.Execute(ctx, retrySpec, retryExecOpts)
 		if retryErr != nil {
 			_ = p.Issues().AddComment(ctx, params.IssueNumber,
@@ -923,6 +1075,10 @@ func execStandalone(ctx context.Context, p platform.Platform, ag agent.Agent, cf
 
 		validation = runValidation(ctx, params.RepoRoot)
 		if !validation.allPassed() {
+			_ = removeValidationMarker(params.RepoRoot, params.IssueNumber)
+			_ = writeValidationErrors(params.RepoRoot, params.IssueNumber, validation.Errors)
+			commitValidationStatus(g, params.RepoRoot, params.IssueNumber, fmt.Sprintf("Update validation status for #%d", params.IssueNumber))
+
 			report := buildWorkerReport(g, "origin/"+targetBranch, rawSummary, validation)
 			report += "\n\n⚠️ Validation failed after retry. Worker marked as failed."
 			if rawSummary != "" {
@@ -932,6 +1088,13 @@ func execStandalone(ctx context.Context, p platform.Platform, ag agent.Agent, cf
 			return nil, fmt.Errorf("validation failed after retry: %s", validation.Errors)
 		}
 	}
+
+	// Validation passed — record the marker and clear any saved errors.
+	if err = writeValidationMarker(params.RepoRoot, params.IssueNumber); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: writing validation marker for #%d: %v\n", params.IssueNumber, err)
+	}
+	_ = removeValidationErrors(params.RepoRoot, params.IssueNumber)
+	commitValidationStatus(g, params.RepoRoot, params.IssueNumber, fmt.Sprintf("Update validation status for #%d", params.IssueNumber))
 
 	if err = g.Push("origin", targetBranch); err != nil {
 		errStr := err.Error()

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -2185,6 +2185,11 @@ func TestExec_ResumeInvokesAgentWhenValidationFailedLastTime(t *testing.T) {
 	require.GreaterOrEqual(t, ag.calls, 1, "agent must be invoked when the marker is absent")
 	assert.Contains(t, ag.bodies[0], errText,
 		"the saved previous-attempt validation errors must be injected into the agent body")
+	require.GreaterOrEqual(t, len(ag.prompts), 1, "agent must be invoked with a rendered system prompt")
+	assert.NotContains(t, ag.prompts[0], "Do not redo completed work",
+		"the resume-after-validation-failure prompt must use the retry variant and NOT instruct the agent to honor the stale progress file")
+	assert.Contains(t, ag.prompts[0], "STALE",
+		"the resume-after-validation-failure prompt must tell the agent the progress file is stale")
 }
 
 func TestExec_RetryAgentDoesNotHonorProgressFile(t *testing.T) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/herd-os/herd/internal/agent"
 	"github.com/herd-os/herd/internal/config"
+	"github.com/herd-os/herd/internal/git"
 	"github.com/herd-os/herd/internal/issues"
 	"github.com/herd-os/herd/internal/platform"
 	"github.com/stretchr/testify/assert"
@@ -2305,6 +2306,38 @@ func TestExec_ValidationMarkerLifecycle(t *testing.T) {
 		"marker must be removed before the agent runs so a stale pass cannot carry over")
 	assert.True(t, checkValidationPassed(repoDir, 42),
 		"marker must be re-created after re-validation passes")
+}
+
+func TestCommitValidationStatus_StagesErrorsFileDeletion(t *testing.T) {
+	// Verify FAIL → PASS transition removes the errors file from the worker
+	// branch HEAD, not just from the worktree, so a future resume-after-failure
+	// path does not read stale errors.
+	repoDir := initTestRepoWithBatchBranch(t)
+	gitRunT(t, repoDir, "git", "checkout", "herd/batch/1-batch")
+	gitRunT(t, repoDir, "git", "checkout", "-b", "herd/worker/99-test")
+	g := git.New(repoDir)
+	gitRunT(t, repoDir, "git", "config", "user.name", "t")
+	gitRunT(t, repoDir, "git", "config", "user.email", "t@t.com")
+
+	// Phase 1 — simulate a failed validation: errors file written and committed.
+	require.NoError(t, writeValidationErrors(repoDir, 99, "initial failure"))
+	commitValidationStatus(g, repoDir, 99, "Update validation status for #99")
+	out, err := exec.Command("git", "-C", repoDir, "ls-files", ".herd/progress").CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "99.validation.errors",
+		"errors file must be tracked after the failure commit")
+
+	// Phase 2 — simulate the successful re-validation: marker written, errors removed.
+	require.NoError(t, writeValidationMarker(repoDir, 99))
+	require.NoError(t, removeValidationErrors(repoDir, 99))
+	commitValidationStatus(g, repoDir, 99, "Update validation status for #99")
+
+	out, err = exec.Command("git", "-C", repoDir, "ls-files", ".herd/progress").CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "99.validation",
+		"marker file must be tracked after the success commit")
+	assert.NotContains(t, string(out), "99.validation.errors",
+		"errors file must be removed from HEAD when validation passes, not just from the worktree")
 }
 
 func TestExecStandalone_RetryAgentDoesNotHonorProgressFile(t *testing.T) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -75,7 +75,7 @@ func (m *mockPRService) ListReviewComments(_ context.Context, _ int) ([]*platfor
 	return nil, nil
 }
 func (m *mockPRService) GetDiff(_ context.Context, _ int) (string, error) { return "", nil }
-func (m *mockPRService) Close(_ context.Context, _ int) error              { return nil }
+func (m *mockPRService) Close(_ context.Context, _ int) error             { return nil }
 
 type mockPlatform struct {
 	issues     *mockIssueService
@@ -86,25 +86,25 @@ type mockPlatform struct {
 }
 
 func (m *mockPlatform) Issues() platform.IssueService             { return m.issues }
-func (m *mockPlatform) PullRequests() platform.PullRequestService  { return m.prs }
-func (m *mockPlatform) Workflows() platform.WorkflowService        { return m.workflows }
-func (m *mockPlatform) Labels() platform.LabelService              { return nil }
-func (m *mockPlatform) Milestones() platform.MilestoneService      { return m.milestones }
-func (m *mockPlatform) Runners() platform.RunnerService            { return nil }
-func (m *mockPlatform) Repository() platform.RepositoryService     { return m.repo }
+func (m *mockPlatform) PullRequests() platform.PullRequestService { return m.prs }
+func (m *mockPlatform) Workflows() platform.WorkflowService       { return m.workflows }
+func (m *mockPlatform) Labels() platform.LabelService             { return nil }
+func (m *mockPlatform) Milestones() platform.MilestoneService     { return m.milestones }
+func (m *mockPlatform) Runners() platform.RunnerService           { return nil }
+func (m *mockPlatform) Repository() platform.RepositoryService    { return m.repo }
 func (m *mockPlatform) Checks() platform.CheckService             { return nil }
 
 type mockIssueService struct {
-	mu                sync.Mutex
-	getResult         *platform.Issue
-	getErr            error
-	addedLabels       []string
-	removedLabels     []string
-	comments          []string
-	updatedIssues     map[int]platform.IssueUpdate
-	nextCommentID     int64
-	updatedComments   map[int64]string
-	deletedComments   []int64
+	mu              sync.Mutex
+	getResult       *platform.Issue
+	getErr          error
+	addedLabels     []string
+	removedLabels   []string
+	comments        []string
+	updatedIssues   map[int]platform.IssueUpdate
+	nextCommentID   int64
+	updatedComments map[int64]string
+	deletedComments []int64
 }
 
 func (m *mockIssueService) Create(_ context.Context, _, _ string, _ []string, _ *int) (*platform.Issue, error) {
@@ -190,7 +190,7 @@ func (m *mockRepoService) GetInfo(_ context.Context) (*platform.RepoInfo, error)
 func (m *mockRepoService) GetDefaultBranch(_ context.Context) (string, error) {
 	return m.defaultBranch, nil
 }
-func (m *mockRepoService) CreateBranch(_ context.Context, _, _ string) error   { return nil }
+func (m *mockRepoService) CreateBranch(_ context.Context, _, _ string) error { return nil }
 func (m *mockRepoService) DeleteBranch(_ context.Context, name string) error {
 	m.deletedBranches = append(m.deletedBranches, name)
 	return nil
@@ -221,7 +221,7 @@ func (m *mockMilestoneService) Update(_ context.Context, _ int, _ platform.Miles
 
 func TestRenderWorkerPrompt(t *testing.T) {
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Add auth", "## Task\nBuild it", 42, "herd/worker/42-add-auth", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Add auth", "## Task\nBuild it", 42, "herd/worker/42-add-auth", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "Add auth")
 	assert.Contains(t, prompt, "## Task\nBuild it")
@@ -239,7 +239,7 @@ func TestRenderWorkerPromptWithRoleInstructions(t *testing.T) {
 	require.NoError(t, os.WriteFile(dir+"/.herd/worker.md", []byte("Use table-driven tests"), 0644))
 
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Task", "Body", 1, "herd/worker/1-task", dir, cfg)
+	prompt, err := renderWorkerPrompt("Task", "Body", 1, "herd/worker/1-task", dir, cfg, false)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "Use table-driven tests")
 	assert.Contains(t, prompt, "Project-Specific Instructions")
@@ -247,7 +247,7 @@ func TestRenderWorkerPromptWithRoleInstructions(t *testing.T) {
 
 func TestRenderWorkerPrompt_IncludesBranchDiscipline(t *testing.T) {
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Add auth", "## Task\nBuild it", 42, "herd/worker/42-add-auth", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Add auth", "## Task\nBuild it", 42, "herd/worker/42-add-auth", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	for _, want := range []string{
 		"Branch & PR Discipline",
@@ -264,7 +264,7 @@ func TestRenderWorkerPrompt_IncludesBranchDiscipline(t *testing.T) {
 
 func TestRenderWorkerPrompt_BranchDisciplineBeforeTask(t *testing.T) {
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Add auth", "create a new branch BODY-MARKER-XYZ", 42, "herd/worker/42-add-auth", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Add auth", "create a new branch BODY-MARKER-XYZ", 42, "herd/worker/42-add-auth", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	disciplineIdx := strings.Index(prompt, "Branch & PR Discipline")
 	taskIdx := strings.Index(prompt, "BODY-MARKER-XYZ")
@@ -337,7 +337,7 @@ func TestWorkerPrompt_CoAuthorTrailer(t *testing.T) {
 			cfg := &config.Config{
 				PullRequests: config.PullRequests{CoAuthorEmail: tt.coAuthorEmail},
 			}
-			prompt, err := renderWorkerPrompt("Task", "Body", 1, "herd/worker/1-task", t.TempDir(), cfg)
+			prompt, err := renderWorkerPrompt("Task", "Body", 1, "herd/worker/1-task", t.TempDir(), cfg, false)
 			require.NoError(t, err)
 
 			if tt.expectTrailer {
@@ -825,7 +825,7 @@ func TestExec_HTTPClientNil_SkipsImageDownload(t *testing.T) {
 func TestPromptTemplate_AllInstructions(t *testing.T) {
 	// Verify all 8 instruction bullets from the spec are present
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Title", "Body", 1, "herd/worker/1-title", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Title", "Body", 1, "herd/worker/1-title", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 
 	expectedPhrases := []string{
@@ -1045,7 +1045,7 @@ func TestExec_FreshBranchWhenNoRemote(t *testing.T) {
 func TestRenderWorkerPrompt_FixIssue(t *testing.T) {
 	body := "---\nherd:\n  version: 1\n  type: fix\n---\n\n## Task\nFix the bug"
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Fix bug", body, 10, "herd/worker/10-fix-bug", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Fix bug", body, 10, "herd/worker/10-fix-bug", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "This is a fix issue created by the reviewer")
 	assert.Contains(t, prompt, "Do not dismiss")
@@ -1064,7 +1064,7 @@ func TestRenderWorkerPrompt_NonFixIssue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{}
-			prompt, err := renderWorkerPrompt("Task", tt.body, 1, "herd/worker/1-task", t.TempDir(), cfg)
+			prompt, err := renderWorkerPrompt("Task", tt.body, 1, "herd/worker/1-task", t.TempDir(), cfg, false)
 			require.NoError(t, err)
 			assert.NotContains(t, prompt, "This is a fix issue")
 		})
@@ -1074,7 +1074,7 @@ func TestRenderWorkerPrompt_NonFixIssue(t *testing.T) {
 func TestRenderWorkerPrompt_FixIssueWithMalformedFrontmatter(t *testing.T) {
 	body := "---\nherd:\n  version: [invalid yaml\n---\n\n## Task\nDo something"
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Task", body, 1, "herd/worker/1-task", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Task", body, 1, "herd/worker/1-task", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	assert.NotContains(t, prompt, "This is a fix issue")
 }
@@ -1136,7 +1136,7 @@ func TestNoOpVerdictHeader(t *testing.T) {
 
 func TestWorkerPromptTemplate_RequiresVerdictFormat(t *testing.T) {
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Add auth", "## Task\nBuild it", 42, "herd/worker/42-add-auth", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Add auth", "## Task\nBuild it", 42, "herd/worker/42-add-auth", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "Findings reviewed against the current code:",
 		"prompt must require the Findings header")
@@ -1385,7 +1385,7 @@ func TestExec_NonConflictNoOp_NotClosed(t *testing.T) {
 
 func TestRenderWorkerPrompt_ContainsConflictInstruction(t *testing.T) {
 	cfg := &config.Config{}
-	prompt, err := renderWorkerPrompt("Resolve conflict", "## Task\nFix it", 42, "herd/worker/42-resolve", t.TempDir(), cfg)
+	prompt, err := renderWorkerPrompt("Resolve conflict", "## Task\nFix it", 42, "herd/worker/42-resolve", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "merge or rebase conflict")
 	assert.Contains(t, prompt, "resolve the actual conflict")
@@ -1471,6 +1471,9 @@ func TestExec_SkipsAgentWhenProgressComplete(t *testing.T) {
 		[]byte("- [x] Create auth model\n- [x] Add validation\n- [x] Write tests\n"),
 		0o644,
 	))
+	// Write the validation marker too — the skip path now requires BOTH the
+	// completed progress file AND the worker-written validation marker.
+	require.NoError(t, writeValidationMarker(repoDir, 42))
 	// Commit the progress file so the branch has changes
 	run(repoDir, "git", "add", ".")
 	run(repoDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "progress")
@@ -1994,7 +1997,7 @@ func TestExecStandalone_ImagesAndProgress(t *testing.T) {
 
 func TestRenderStandalonePrompt(t *testing.T) {
 	cfg := &config.Config{}
-	prompt, err := renderStandalonePrompt("Fix it", "## Task\nDo the thing", 590, "feature/headbranch", t.TempDir(), cfg)
+	prompt, err := renderStandalonePrompt("Fix it", "## Task\nDo the thing", 590, "feature/headbranch", t.TempDir(), cfg, false)
 	require.NoError(t, err)
 
 	for _, want := range []string{
@@ -2030,9 +2033,457 @@ func TestRenderStandalonePrompt_WithRoleAndCoAuthor(t *testing.T) {
 	cfg := &config.Config{
 		PullRequests: config.PullRequests{CoAuthorEmail: "123+herd-os[bot]@users.noreply.github.com"},
 	}
-	prompt, err := renderStandalonePrompt("Fix", "Body", 1, "feature/x", dir, cfg)
+	prompt, err := renderStandalonePrompt("Fix", "Body", 1, "feature/x", dir, cfg, false)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "Use table-driven tests")
 	assert.Contains(t, prompt, "Project-Specific Instructions")
 	assert.Contains(t, prompt, "Co-authored-by: herd-os[bot]")
+}
+
+// --- Validation marker gating tests ---
+
+// scriptedAgent is a fake agent that captures the system prompt and task body
+// of each Execute call and runs a per-call side effect (e.g. making a commit).
+// It returns scripted results so a single test can drive multiple invocations
+// (e.g. an initial run followed by a validation-failure retry).
+type scriptedAgent struct {
+	prompts []string
+	bodies  []string
+	calls   int
+	steps   []func(call int) // per-call side effect; indexed by call number
+	results []*agent.ExecResult
+}
+
+func (s *scriptedAgent) Plan(_ context.Context, _ string, _ agent.PlanOptions) (*agent.Plan, error) {
+	return nil, nil
+}
+func (s *scriptedAgent) Execute(_ context.Context, spec agent.TaskSpec, opts agent.ExecOptions) (*agent.ExecResult, error) {
+	idx := s.calls
+	s.prompts = append(s.prompts, opts.SystemPrompt)
+	s.bodies = append(s.bodies, spec.Body)
+	s.calls++
+	if idx < len(s.steps) && s.steps[idx] != nil {
+		s.steps[idx](idx)
+	}
+	if idx < len(s.results) && s.results[idx] != nil {
+		return s.results[idx], nil
+	}
+	return &agent.ExecResult{Summary: "done"}, nil
+}
+func (s *scriptedAgent) Review(_ context.Context, _ string, _ agent.ReviewOptions) (*agent.ReviewResult, error) {
+	return nil, nil
+}
+func (s *scriptedAgent) Discuss(_ context.Context, _ agent.DiscussOptions) error { return nil }
+
+// gitRunT runs a git/other command in dir, failing the test on error.
+func gitRunT(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "command %v failed: %s", args, string(out))
+}
+
+// writeGoModule writes a minimal go.mod and a main.go (valid or broken) into dir.
+func writeGoModule(t *testing.T, dir string, broken bool) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\n\ngo 1.21\n"), 0o644))
+	body := "package main\n\nfunc main() {}\n"
+	if broken {
+		body = "package main\n\nfunc main() { undefinedSymbol() }\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(body), 0o644))
+}
+
+func TestExec_ResumeSkipsAgentWhenValidationPassed(t *testing.T) {
+	repoDir := initTestRepoWithBatchBranch(t)
+
+	gitRunT(t, repoDir, "git", "checkout", "herd/batch/1-batch")
+	gitRunT(t, repoDir, "git", "checkout", "-b", "herd/worker/42-test")
+
+	// Complete progress file AND the validation marker → skip path is allowed.
+	progDir := filepath.Join(repoDir, ".herd", "progress")
+	require.NoError(t, os.MkdirAll(progDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(progDir, "42.md"), []byte("- [x] all done\n"), 0o644))
+	require.NoError(t, writeValidationMarker(repoDir, 42))
+
+	gitRunT(t, repoDir, "git", "add", ".")
+	gitRunT(t, repoDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "progress")
+	gitRunT(t, repoDir, "git", "push", "origin", "herd/worker/42-test")
+
+	issueSvc := &mockIssueService{
+		getResult: &platform.Issue{
+			Number: 42, Title: "Test",
+			Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+		},
+	}
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main", branchSHAErr: nil},
+	}
+
+	ag := &scriptedAgent{}
+
+	result, err := Exec(context.Background(), mock, ag, &config.Config{}, ExecParams{
+		IssueNumber: 42,
+		RepoRoot:    repoDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 0, ag.calls, "agent must NOT be invoked when progress complete and validation passed")
+
+	foundSkip := false
+	for _, c := range issueSvc.comments {
+		if strings.Contains(c, "Worker Report") && strings.Contains(c, "Skipped") {
+			foundSkip = true
+		}
+	}
+	assert.True(t, foundSkip, "report should mention skipping")
+}
+
+func TestExec_ResumeInvokesAgentWhenValidationFailedLastTime(t *testing.T) {
+	repoDir := initTestRepoWithBatchBranch(t)
+
+	gitRunT(t, repoDir, "git", "checkout", "herd/batch/1-batch")
+	gitRunT(t, repoDir, "git", "checkout", "-b", "herd/worker/42-test")
+
+	// Progress complete, NO marker, but a saved errors file from the last attempt.
+	progDir := filepath.Join(repoDir, ".herd", "progress")
+	require.NoError(t, os.MkdirAll(progDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(progDir, "42.md"), []byte("- [x] all done\n"), 0o644))
+	const errText = "UNIQUE_VALIDATION_ERROR_MARKER_XYZ"
+	require.NoError(t, writeValidationErrors(repoDir, 42, errText))
+
+	gitRunT(t, repoDir, "git", "add", ".")
+	gitRunT(t, repoDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "progress+errors")
+	gitRunT(t, repoDir, "git", "push", "origin", "herd/worker/42-test")
+
+	issueSvc := &mockIssueService{
+		getResult: &platform.Issue{
+			Number: 42, Title: "Test",
+			Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+		},
+	}
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main", branchSHAErr: nil},
+	}
+
+	ag := &scriptedAgent{}
+
+	_, err := Exec(context.Background(), mock, ag, &config.Config{}, ExecParams{
+		IssueNumber: 42,
+		RepoRoot:    repoDir,
+	})
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, ag.calls, 1, "agent must be invoked when the marker is absent")
+	assert.Contains(t, ag.bodies[0], errText,
+		"the saved previous-attempt validation errors must be injected into the agent body")
+}
+
+func TestExec_RetryAgentDoesNotHonorProgressFile(t *testing.T) {
+	repoDir := initTestRepoWithBatchBranch(t)
+
+	issueSvc := &mockIssueService{
+		getResult: &platform.Issue{
+			Number: 42, Title: "Test",
+			Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+		},
+	}
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main", branchSHAErr: fmt.Errorf("not found")},
+	}
+
+	ag := &scriptedAgent{
+		steps: []func(call int){
+			// First invocation: introduce broken code so validation fails.
+			func(_ int) {
+				writeGoModule(t, repoDir, true)
+				gitRunT(t, repoDir, "git", "add", ".")
+				gitRunT(t, repoDir, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "broken")
+			},
+			// Retry invocation: fix the code so validation passes.
+			func(_ int) {
+				writeGoModule(t, repoDir, false)
+				gitRunT(t, repoDir, "git", "add", ".")
+				gitRunT(t, repoDir, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "fixed")
+			},
+		},
+	}
+
+	_, err := Exec(context.Background(), mock, ag, &config.Config{}, ExecParams{
+		IssueNumber: 42,
+		RepoRoot:    repoDir,
+	})
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(ag.prompts), 2, "expected an initial run and a validation-failure retry")
+	assert.Contains(t, ag.prompts[0], "Do not redo completed work",
+		"the initial prompt should still carry the incremental-progress guidance")
+	assert.NotContains(t, ag.prompts[1], "Do not redo completed work",
+		"the retry prompt must NOT instruct the agent to honor the stale progress file")
+}
+
+func TestExec_ValidationMarkerLifecycle(t *testing.T) {
+	repoDir := initTestRepoWithBatchBranch(t)
+
+	issueSvc := &mockIssueService{
+		getResult: &platform.Issue{
+			Number: 42, Title: "Test",
+			Milestone: &platform.Milestone{Number: 1, Title: "Batch"},
+		},
+	}
+
+	// Phase 1: fresh run; agent writes valid code and validation passes.
+	freshMock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main", branchSHAErr: fmt.Errorf("not found")},
+	}
+	freshAgent := &scriptedAgent{
+		steps: []func(call int){
+			func(_ int) {
+				writeGoModule(t, repoDir, false)
+				gitRunT(t, repoDir, "git", "add", ".")
+				gitRunT(t, repoDir, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "work")
+			},
+		},
+	}
+
+	_, err := Exec(context.Background(), freshMock, freshAgent, &config.Config{}, ExecParams{
+		IssueNumber: 42,
+		RepoRoot:    repoDir,
+	})
+	require.NoError(t, err)
+	assert.True(t, checkValidationPassed(repoDir, 42),
+		"marker must exist on disk after a successful validation")
+
+	// Phase 2: resume run; the marker must be removed at the start of the agent
+	// invocation, then re-created after re-validation passes.
+	var markerPresentAtInvocation bool
+	resumeMock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main", branchSHAErr: nil},
+	}
+	resumeAgent := &scriptedAgent{
+		steps: []func(call int){
+			func(_ int) {
+				markerPresentAtInvocation = checkValidationPassed(repoDir, 42)
+				// Make a fresh change so the run is not a no-op.
+				require.NoError(t, os.WriteFile(filepath.Join(repoDir, "extra.txt"), []byte("more"), 0o644))
+				gitRunT(t, repoDir, "git", "add", ".")
+				gitRunT(t, repoDir, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "more work")
+			},
+		},
+	}
+
+	_, err = Exec(context.Background(), resumeMock, resumeAgent, &config.Config{}, ExecParams{
+		IssueNumber: 42,
+		RepoRoot:    repoDir,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, resumeAgent.calls, "resume run must invoke the agent")
+	assert.False(t, markerPresentAtInvocation,
+		"marker must be removed before the agent runs so a stale pass cannot carry over")
+	assert.True(t, checkValidationPassed(repoDir, 42),
+		"marker must be re-created after re-validation passes")
+}
+
+func TestExecStandalone_RetryAgentDoesNotHonorProgressFile(t *testing.T) {
+	targetBranch := "feature/standalone-retry"
+	work, _ := initTestRepoWithTargetBranch(t, targetBranch)
+
+	issueSvc := &mockIssueService{
+		getResult: &platform.Issue{
+			Number: 700,
+			Title:  "Fix",
+			Body:   standaloneIssueBody(targetBranch, 321),
+		},
+		updatedIssues: make(map[int]platform.IssueUpdate),
+	}
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+	}
+
+	ag := &scriptedAgent{
+		steps: []func(call int){
+			func(_ int) {
+				writeGoModule(t, work, true)
+				gitRunT(t, work, "git", "add", ".")
+				gitRunT(t, work, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "broken")
+			},
+			func(_ int) {
+				writeGoModule(t, work, false)
+				gitRunT(t, work, "git", "add", ".")
+				gitRunT(t, work, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "fixed")
+			},
+		},
+	}
+
+	_, err := Exec(context.Background(), mock, ag, &config.Config{}, ExecParams{
+		IssueNumber: 700,
+		RepoRoot:    work,
+		Mode:        "standalone",
+	})
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(ag.prompts), 2, "expected an initial run and a validation-failure retry")
+	assert.Contains(t, ag.prompts[0], "Do not redo completed work")
+	assert.NotContains(t, ag.prompts[1], "Do not redo completed work",
+		"the standalone retry prompt must NOT instruct the agent to honor the stale progress file")
+}
+
+func TestExecStandalone_ValidationMarkerLifecycle(t *testing.T) {
+	targetBranch := "feature/standalone-marker"
+	work, _ := initTestRepoWithTargetBranch(t, targetBranch)
+
+	issueSvc := &mockIssueService{
+		getResult: &platform.Issue{
+			Number: 701,
+			Title:  "Fix",
+			Body:   standaloneIssueBody(targetBranch, 322),
+		},
+		updatedIssues: make(map[int]platform.IssueUpdate),
+	}
+	mock := &mockPlatform{
+		issues:    issueSvc,
+		prs:       &mockPRService{},
+		workflows: &mockWorkflowService{},
+		repo:      &mockRepoService{defaultBranch: "main"},
+	}
+
+	// Phase 1: agent writes valid code, validation passes, marker created.
+	phase1 := &scriptedAgent{
+		steps: []func(call int){
+			func(_ int) {
+				writeGoModule(t, work, false)
+				gitRunT(t, work, "git", "add", ".")
+				gitRunT(t, work, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "work")
+			},
+		},
+	}
+	_, err := Exec(context.Background(), mock, phase1, &config.Config{}, ExecParams{
+		IssueNumber: 701,
+		RepoRoot:    work,
+		Mode:        "standalone",
+	})
+	require.NoError(t, err)
+	assert.True(t, checkValidationPassed(work, 701), "marker must exist after successful validation")
+
+	// Phase 2: re-run; marker removed at agent start, re-created after re-validation.
+	var markerPresentAtInvocation bool
+	phase2 := &scriptedAgent{
+		steps: []func(call int){
+			func(_ int) {
+				markerPresentAtInvocation = checkValidationPassed(work, 701)
+				require.NoError(t, os.WriteFile(filepath.Join(work, "extra.txt"), []byte("more"), 0o644))
+				gitRunT(t, work, "git", "add", ".")
+				gitRunT(t, work, "git", "-c", "user.name=t", "-c", "user.email=t@t.com", "commit", "-m", "more")
+			},
+		},
+	}
+	_, err = Exec(context.Background(), mock, phase2, &config.Config{}, ExecParams{
+		IssueNumber: 701,
+		RepoRoot:    work,
+		Mode:        "standalone",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, phase2.calls, "re-run must invoke the agent")
+	assert.False(t, markerPresentAtInvocation,
+		"marker must be removed before the agent runs")
+	assert.True(t, checkValidationPassed(work, 701),
+		"marker must be re-created after re-validation passes")
+}
+
+func TestWriteValidationErrors_TruncatesLargeOutput(t *testing.T) {
+	dir := t.TempDir()
+	large := strings.Repeat("E", validationErrorsMaxBytes+5000)
+	require.NoError(t, writeValidationErrors(dir, 9, large))
+
+	got, ok := readValidationErrors(dir, 9)
+	require.True(t, ok)
+	assert.LessOrEqual(t, len(got), validationErrorsMaxBytes+len("...(truncated)...\n"),
+		"output must be truncated to within the documented bound")
+	assert.Contains(t, got, "...(truncated)...")
+	// The tail (most recent errors) must be preserved.
+	assert.True(t, strings.HasSuffix(got, "E"), "tail of the errors should be kept")
+}
+
+func TestWriteValidationErrors_SmallOutputNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, writeValidationErrors(dir, 9, "small error"))
+	got, ok := readValidationErrors(dir, 9)
+	require.True(t, ok)
+	assert.Equal(t, "small error", got)
+}
+
+func TestReadValidationErrors_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	got, ok := readValidationErrors(dir, 123)
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestValidationMarker_WriteCheckRemove(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name string
+		fn   func(t *testing.T)
+	}{
+		{"absent initially", func(t *testing.T) {
+			assert.False(t, checkValidationPassed(dir, 5))
+		}},
+		{"present after write", func(t *testing.T) {
+			require.NoError(t, writeValidationMarker(dir, 5))
+			assert.True(t, checkValidationPassed(dir, 5))
+		}},
+		{"absent after remove", func(t *testing.T) {
+			require.NoError(t, removeValidationMarker(dir, 5))
+			assert.False(t, checkValidationPassed(dir, 5))
+		}},
+		{"remove missing is not an error", func(t *testing.T) {
+			require.NoError(t, removeValidationMarker(dir, 5))
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { tt.fn(t) })
+	}
+}
+
+func TestRemoveValidationErrors_MissingFileNoError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, removeValidationErrors(dir, 1))
+	require.NoError(t, writeValidationErrors(dir, 1, "x"))
+	require.NoError(t, removeValidationErrors(dir, 1))
+	_, ok := readValidationErrors(dir, 1)
+	assert.False(t, ok)
+}
+
+func TestRenderWorkerRetryPrompt_OmitsProgressGuidance(t *testing.T) {
+	cfg := &config.Config{}
+	retry, err := renderWorkerPrompt("T", "B", 7, "herd/worker/7-t", t.TempDir(), cfg, true)
+	require.NoError(t, err)
+	assert.NotContains(t, retry, "Do not redo completed work")
+	assert.Contains(t, retry, "Stale Progress")
+
+	normal, err := renderWorkerPrompt("T", "B", 7, "herd/worker/7-t", t.TempDir(), cfg, false)
+	require.NoError(t, err)
+	assert.Contains(t, normal, "Do not redo completed work")
 }


### PR DESCRIPTION
## Summary

Batch **Fix worker retry loop stuck on validation failure (progress-file short-circuit)** — 2 tasks across 2 tiers.

## Tasks

| Issue | Title | Tier | Status |
|-------|-------|------|--------|
| #656 | Document validation-marker gating in design + command docs | 1 | done |
| #655 | Add validation-marker gating to worker retry/resume (impl + tests) | 0 | done |

## Worker branches

- `herd/worker/656-document-validation-marker-gating-in-design-comman`
- `herd/worker/655-add-validation-marker-gating-to-worker-retryresume`
