### PR TITLE
Install git in AUR publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             -e AUR_SSH_PRIVATE_KEY \
             -v "$PWD:/work" -w /work \
             archlinux:base-devel \
-            bash -c "pacman -Sy --noconfirm --needed openssh && ./scripts/update-aur.sh $VERSION bin/checksums.txt"
+            bash -c "pacman -Sy --noconfirm --needed git openssh && ./scripts/update-aur.sh $VERSION bin/checksums.txt"
 
   # NOTE: The first time this package is pushed, GHCR creates it as
   # private. The herd-runner-base package must be made


### PR DESCRIPTION
## Summary
- `archlinux:base-devel` does not include `git` (base-devel is the GCC/autoconf toolchain meta-package). `scripts/update-aur.sh` died at the first `git clone` in the v0.8.3 release workflow run with `./scripts/update-aur.sh: line 63: git: command not found`.
- One-line fix: add `git` to the `pacman -Sy --noconfirm --needed` install list, alongside the existing `openssh`.

## Test plan
- [x] v0.8.3 release log shows the exact failure mode (openssh installs, then git missing at line 63 of update-aur.sh)
- [ ] Tag v0.8.4 (or any subsequent tag) and confirm the `Update AUR (herd-bin)` step completes; verify `herd-bin` on AUR moves to the new version