### PR TITLE
Let builder traverse the mktemp parent dir in AUR publish

### DIFF
--- a/scripts/update-aur.sh
+++ b/scripts/update-aur.sh
@@ -99,6 +99,10 @@ if [[ ${EUID} -eq 0 ]]; then
 	if ! id -u builder >/dev/null 2>&1; then
 		useradd -m builder
 	fi
+	# mktemp -d creates the parent at 0700 root-owned, which blocks builder from
+	# traversing into the clone — makepkg's BUILDDIR writability check then fails
+	# with "Failed to create the directory $BUILDDIR" even though the dir exists.
+	chmod 755 "${TMPDIR}"
 	chown -R builder .
 	runuser -u builder -- makepkg --printsrcinfo > .SRCINFO
 	chown -R root:root .


### PR DESCRIPTION
## Summary

Follow-up to #660. `scripts/update-aur.sh` drops to a `builder` user via `runuser` because `makepkg` refuses to run as root. But `mktemp -d` creates its parent at `0700` root-owned, so `builder` cannot traverse into the cloned worktree — `makepkg`'s BUILDDIR-writability check then fails with `==> ERROR: Failed to create the directory $BUILDDIR (/tmp/tmp.XXX/herd-bin)` even though the directory exists.

`chmod 755` the mktemp parent before the chown round-trip so `builder` can reach the worktree. Local Arch runs are unaffected (the script only takes this branch when `EUID == 0`).

## Test plan
- [x] Reproduced in the v0.8.4 release log: `Cloning into '/tmp/tmp.X/herd-bin'...` succeeds (git fix from #660 landed) → `==> ERROR: Failed to create the directory $BUILDDIR` from makepkg as `builder`
- [ ] Tag the next version and confirm the `Update AUR (herd-bin)` step completes; verify `herd-bin` on AUR moves to the new version