### PR TITLE
Smoke test: switch agent to opencode + Claude OAuth bridge

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -4,9 +4,9 @@ platform:
     owner: Herd-OS
     repo: herd
 agent:
-    provider: claude
+    provider: opencode
     binary: ""
-    model: "opus"
+    model: "anthropic/claude-opus-4-8"
 workers:
     max_concurrent: 3
     runner_label: herd-worker


### PR DESCRIPTION
## Summary
- Temporary config flip to exercise the `opencode-claude-auth` bridge added in #654 on a real worker run.
- `agent.provider: claude` → `opencode`, `agent.model: opus` → `anthropic/claude-opus-4-8` (OpenCode's `provider/model` form).
- No new secrets — the bridge reuses the existing `CLAUDE_CODE_OAUTH_TOKEN` already on the runner.

## Test plan
- [ ] Runners pulled `ghcr.io/herd-os/herd-runner-base:latest` (v0.8.5) and restarted, so `entrypoint.herd.sh` installs `opencode-claude-auth@1.5.4`
- [ ] Merge this PR so workers reading `.herdos.yml` pick up the new provider/model
- [ ] Dispatch a trivial task and confirm the worker authenticates via OpenCode + the bridge (no `401` / `no API key` / `ANTHROPIC_API_KEY missing` errors)
- [ ] If it works: keep this config (or open a follow-up that clears the TODO(verify) markers in `internal/agent/opencode/auth.go`)
- [ ] If it fails on auth: most likely the plugin needs a credential file rather than reading `CLAUDE_CODE_OAUTH_TOKEN` from env — open a follow-up to add a `provisionClaudeOAuthFile` step. Revert this PR in the meantime.