### PR TITLE
Rebuild custom runner image on every herd release

### DIFF
--- a/.github/workflows/herd-publish-runner.yml
+++ b/.github/workflows/herd-publish-runner.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'Dockerfile.herd_runner'
     branches: [ main ]
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/internal/cli/workflows/herd-publish-runner.yml.tmpl
+++ b/internal/cli/workflows/herd-publish-runner.yml.tmpl
@@ -5,6 +5,8 @@ on:
     paths:
       - 'Dockerfile.herd_runner'
     branches: [ main ]
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `herd-publish-runner.yml` builds `ghcr.io/<org>/<repo>-herd-runner` from the user's `Dockerfile.herd_runner`, which extends `ghcr.io/herd-os/herd-runner-base`. The base image rebuilds on every release via `release.yml`'s `publish-base-image` job, but the customized runner image only rebuilt when `Dockerfile.herd_runner` itself changed — so base updates (new agent CLIs, entrypoint changes) sat stale until that file was manually touched. Caught while debugging a stale `herd-herd-runner` after the v0.8.3–v0.8.5 base rebuilds.
- Adds a `release: types: [published]` trigger so a new GitHub Release fires the publish workflow automatically and the customized image always tracks the base it extends.

## Test plan
- [ ] Merge this PR
- [ ] Cut the next herd release (e.g. v0.8.6) and confirm `Herd Publish Runner Image` fires on the release-published event
- [ ] On the runner host: `docker pull ghcr.io/<org>/<repo>-herd-runner:latest` and confirm the digest matches the just-built image