### PR TITLE
Use bare model ID claude-opus-4-8 for OpenCode

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -6,7 +6,7 @@ platform:
 agent:
     provider: opencode
     binary: ""
-    model: "anthropic/claude-opus-4-8"
+    model: "claude-opus-4-8"
 workers:
     max_concurrent: 3
     runner_label: herd-worker


### PR DESCRIPTION
## Summary

OpenCode's model registry uses bare IDs, not `provider/model`. The smoke-test worker (from PR #662) died with:

\`\`\`
Error: Model not found: anthropic/claude-opus-4-8.
Did you mean: claude-opus-4-8, claude-opus-4-8-fast, claude-opus-4-1-20250805?
\`\`\`

Flipping \`.herdos.yml\` to the bare ID lets OpenCode resolve the model.

## Known follow-ups (not in this PR)

1. **Auth bridge credential intake**: the same worker log shows \`opencode-claude-auth: No Claude Code credentials found. Running in API key mode with transform hook enabled.\` That confirms the TODO(verify) in \`internal/agent/opencode/auth.go\`: the plugin reads the credentials FILE that \`claude setup-token\` writes, not the \`CLAUDE_CODE_OAUTH_TOKEN\` env var. \`provisionOpenCodeAuth\` needs to write that file from the env var. Separate batch.

2. **Docs**: \`docs/configuration.md\` and \`docs/runners.md\` still document \`anthropic/claude-sonnet-4\` as the example model form (carried over from #654). Need to fix those once we also verify whether \`openai/<model>\` needs the prefix dropped or keeps it.

## Test plan
- [x] PR opened. \`HERD_ENABLED\` is currently \`false\` on \`Herd-OS/herd\` to stop the worker crash loop while the auth bridge follow-up is in flight.
- [ ] After the auth-bridge fix lands, re-enable HERD_ENABLED, dispatch a smoke-test task, and confirm the worker resolves the model AND authenticates via the bridge.