### PR TITLE
Document direct `docker run` as a peer to Docker Compose

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ This will:
 2. **Create `.herd/` directory** — with empty role instruction files (`planner.md`, `worker.md`, `integrator.md`) for customizing agent behavior per role
 3. **Create GitHub labels** — the `herd/*` label taxonomy used to track issue status and type
 4. **Install workflow files** — GitHub Actions workflows for workers, integrator, and monitor in `.github/workflows/`
-5. **Create runner files** — `Dockerfile.herd_runner` (which `FROM`s the published `ghcr.io/herd-os/herd-runner-base` base image), `docker-compose.herd.yml`, and `.env.herd.example` for self-hosted runner setup
+5. **Create runner files** — `Dockerfile.herd_runner` (which `FROM`s the published `ghcr.io/herd-os/herd-runner-base` base image), `docker-compose.herd.yml`, and `.env.herd.example` for self-hosted runner setup (you can also run the container directly with `docker run` — see [Deployment options](runners.md#deployment-options))
 6. **Commit and open a PR** — creates a `herd/init-<version>` branch, commits all generated files, pushes, and opens a PR. Review and merge the PR to apply the changes.
 
 The installed version is recorded in `.herd/state/version` (gitignored) and used on subsequent runs to decide between install, update, and sync.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -117,10 +117,16 @@ You can preview what would change first with `herd init --check`, which re-rende
 
 ### Update runner containers
 
-Runner containers automatically download the latest herd binary on startup. Just restart them:
+Runner containers automatically download the latest herd binary on startup. Just restart them — for Docker Compose:
 
 ```bash
 docker compose -f docker-compose.herd.yml restart
+```
+
+Or, if you started the runners with [direct `docker run`](runners.md#running-runners-directly-with-docker-run):
+
+```bash
+docker restart herd-worker-1 herd-worker-2 herd-worker-3
 ```
 
 To pin a specific version, set `HERD_VERSION` in `.env`:

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -4,6 +4,15 @@ HerdOS workers run as GitHub Actions on self-hosted runners. Self-hosted runners
 
 `herd init` generates all the files you need: `Dockerfile.herd_runner`, `docker-compose.herd.yml`, and `.env.herd.example`.
 
+## Deployment options
+
+There are two supported ways to run the runner containers. Both produce identical runners — same image, same env vars, same volume requirements — so pick by lifecycle and tooling preference:
+
+- **Docker Compose** (covered in [Quick Setup](#quick-setup) below) — the simplest path for getting started, local development, and most single-machine setups. `herd init` generates `docker-compose.herd.yml` for you.
+- **Direct `docker run`** (covered in [Running runners directly with `docker run`](#running-runners-directly-with-docker-run) below) — useful when you want to manage container lifecycle some other way (systemd, a NAS appliance's container runtime, a private orchestrator, etc.).
+
+Subsequent sections assume Docker Compose for command examples, but every step has a `docker run` equivalent — credentials in `.env`, named volume for `~/.codex`, restart policy on the container.
+
 ## Quick Setup
 
 ```bash
@@ -18,6 +27,50 @@ gh variable set HERD_ENABLED --body true --repo <owner>/<repo>
 ```
 
 Three runners start by default (configurable in `docker-compose.herd.yml`). Workflows are inactive until `HERD_ENABLED` is set — this prevents a workflow storm from queued events firing before runners are ready.
+
+Prefer `docker run` directly? See [Running runners directly with `docker run`](#running-runners-directly-with-docker-run) for the equivalent commands.
+
+## Running runners directly with `docker run`
+
+If you'd rather not use Docker Compose — common reason: you're running on a NAS appliance, behind systemd, or under a private orchestrator — the same `Dockerfile.herd_runner` runs identically with plain `docker run`. The image, env vars, and volume requirements are the same as the Compose path; you're just supplying them to the Docker CLI directly.
+
+```bash
+# 1. Build the customized runner image (equivalent to `docker compose build`):
+docker build -t herd-runner -f Dockerfile.herd_runner .
+
+# 2. Run one container (equivalent to one replica of the compose `worker` service):
+docker run -d \
+  --name herd-worker-1 \
+  --restart unless-stopped \
+  --env-file .env \
+  -v codex-auth:/home/runner/.codex \
+  herd-runner
+
+# 3. Run N parallel containers (equivalent to `up -d --scale worker=N`):
+for i in 1 2 3; do
+  docker run -d \
+    --name herd-worker-$i \
+    --restart unless-stopped \
+    --env-file .env \
+    -v codex-auth:/home/runner/.codex \
+    herd-runner
+done
+
+# 4. Stop / remove a container:
+docker stop herd-worker-1 && docker rm herd-worker-1
+
+# 5. Restart (e.g., to pick up a fresh herd binary after a release):
+docker restart herd-worker-1
+```
+
+Notes:
+
+- **`--env-file .env`** reads the same file Docker Compose does, so the credential setup is identical between the two paths. AI provider auth, `GITHUB_TOKEN`, and the Codex subscription vars all live in `.env` either way (see [Agent Authentication](#2-agent-authentication) below).
+- **`-v codex-auth:/home/runner/.codex`** uses a Docker named volume to persist Codex subscription state across container restarts. If you're not using the Codex subscription auth path, the volume is still harmless to mount and is created lazily by Docker on first use.
+- **`--restart unless-stopped`** mirrors the `restart: always` policy in the generated Compose file. After each ephemeral job, the runner exits and Docker restarts it; the entrypoint re-registers with GitHub for the next job.
+- **Container names matter** when scaling: each runner needs a unique name (which becomes its registered name on GitHub). The `--name herd-worker-$i` pattern above gives you stable, predictable names.
+
+`Dockerfile.herd_runner` is the same file `herd init` generated for Docker Compose — no separate "direct mode" Dockerfile to maintain. Updates to it (e.g., extra `RUN apt-get install` lines for project-specific tools) take effect on the next `docker build`.
 
 ## 1. GitHub Token
 
@@ -62,7 +115,7 @@ The same token works for both. `HERD_GITHUB_TOKEN` is needed because GitHub's au
 
 Authentication depends on which `agent.provider` is configured in `.herdos.yml` (see [configuration.md](configuration.md#agent-providers)).
 
-> **AI provider auth env vars (Claude, OpenCode, Codex, Gemini) belong only in the runner's `.env`, not in GitHub Actions secrets.** The worker workflow's `env:` block would override container env unconditionally — surfacing these from secrets either no-ops or shadow-overrides your `.env` value at the step level. The runner container reads them from `.env` via `docker-compose` at startup; the workflow inherits them from the runner process.
+> **AI provider auth env vars (Claude, OpenCode, Codex, Gemini) belong only in the runner's `.env`, not in GitHub Actions secrets.** The worker workflow's `env:` block would override container env unconditionally — surfacing these from secrets either no-ops or shadow-overrides your `.env` value at the step level. The runner container reads them from `.env` at startup (via `docker-compose`'s automatic `env_file` or `docker run --env-file .env`); the workflow inherits them from the runner process.
 
 ### Claude provider (`agent.provider: claude`)
 
@@ -271,7 +324,7 @@ The base image's entrypoint script handles runner lifecycle:
 5. Starts the runner in ephemeral mode (picks up one job, then deregisters)
 6. On SIGTERM/SIGINT, deregisters cleanly
 
-The `docker-compose.herd.yml` runs the worker service with `restart: always`, so after each job completes the container restarts and re-registers for the next job.
+The runner container is started with a restart-always policy (`restart: always` in `docker-compose.herd.yml`, or `--restart unless-stopped` if you're running with [direct `docker run`](#running-runners-directly-with-docker-run)) so after each job completes the container restarts and re-registers for the next job.
 
 ### Project-specific overrides
 
@@ -349,13 +402,30 @@ docker compose -f docker-compose.herd.yml up -d --scale worker=5
 #   replicas: 5
 ```
 
+### Direct `docker run`
+
+Start N containers with unique names — each becomes a separately registered runner:
+
+```bash
+for i in 1 2 3 4 5; do
+  docker run -d \
+    --name herd-worker-$i \
+    --restart unless-stopped \
+    --env-file .env \
+    -v codex-auth:/home/runner/.codex \
+    herd-runner
+done
+```
+
+See [Running runners directly with `docker run`](#running-runners-directly-with-docker-run) for the full command shape and notes.
+
 ### Concurrency control
 
 `workers.max_concurrent` in `.herdos.yml` controls how many workers HerdOS dispatches simultaneously. This is independent of how many runners you have — if you have 5 runners but `max_concurrent: 3`, only 3 will be active at once.
 
 ### Runner labels
 
-`workers.runner_label` in `.herdos.yml` must match the `RUNNER_LABELS` environment variable in `docker-compose.herd.yml`. Default is `herd-worker`. Use different labels to route heavy tasks to specific runners (e.g., `herd-gpu`).
+`workers.runner_label` in `.herdos.yml` must match the `RUNNER_LABELS` environment variable on the runner container (set in `docker-compose.herd.yml`, or via `-e RUNNER_LABELS=…` / `.env` for direct `docker run`). Default is `herd-worker`. Use different labels to route heavy tasks to specific runners (e.g., `herd-gpu`).
 
 ## 8. Cloud Runners
 
@@ -431,7 +501,7 @@ See [configuration.md](configuration.md) for the full field reference.
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | Runner not picking up jobs | Label mismatch | Ensure `RUNNER_LABELS` matches `workers.runner_label` in `.herdos.yml` |
-| Runner exits after one job | Expected | Ephemeral mode — `docker-compose` restarts it automatically |
+| Runner exits after one job | Expected | Ephemeral mode — Docker's restart policy (`restart: always` in Compose, `--restart unless-stopped` for direct `docker run`) brings it back automatically |
 | "Must not run with sudo" | Running as root | The Dockerfile creates a non-root `runner` user — don't override `USER` |
 | Agent not found | Not installed | Ensure the configured agent CLI is in the Docker image — the base image installs both (`npm install -g @anthropic-ai/claude-code` and `npm install -g opencode-ai`) |
 | 403 on PR creation | Org setting | Enable "Allow GitHub Actions to create and approve pull requests" in org settings |


### PR DESCRIPTION
## Summary

The runner docs were heavily anchored on Docker Compose — Quick Setup, scaling, troubleshooting, and several body sentences all assumed it. That made it sound like Compose was the only supported deployment, when in practice the same `Dockerfile.herd_runner` runs identically with a plain `docker run` invocation (useful for NAS appliances, systemd-managed deployments, and private orchestrators that have their own container runtime).

This PR:

- Adds a new **"Deployment options"** subsection at the top of `docs/runners.md` that names both paths neutrally and points users at the right section for each.
- Adds a dedicated **"Running runners directly with `docker run`"** section showing the equivalent build/start/scale/stop commands with explanations of the four moving parts (`--env-file .env` reads the same file Compose does; `-v codex-auth:/home/runner/.codex` is the Codex-subscription persistence volume; `--restart unless-stopped` mirrors Compose's `restart: always`; per-container `--name` is what makes scaling work).
- Adjusts adjacent prose so it doesn't sound Compose-exclusive:
  - The AI-provider-auth principle box mentions both `--env-file` and Compose's automatic env_file loading.
  - The "container restarts after each job" sentence covers both restart policies.
  - The runner-label paragraph mentions setting `RUNNER_LABELS` via either Compose or `-e` / `.env`.
  - The Scaling section grows a parallel "Direct `docker run`" subsection.
  - The "runner exits after one job" troubleshooting row covers both restart-policy mechanisms.
- Light updates in `docs/installation.md` (adds a `docker restart` command alongside `docker compose restart` for runner updates) and `docs/getting-started.md` (the runner-files bullet now mentions `docker run` as an alternative path).

No code or template changes. No new behavior. `herd init --check` passes.

## Test plan

- [x] `herd init --check` — clean.
- [x] Skim each modified doc section in the rendered PR view to confirm the cross-references resolve and the new section's commands are accurate.
- [ ] Pull on the TrueNAS box that already runs the direct-`docker run` path and confirm the documented command shape matches the actual working setup.