### PR TITLE
Rebuild runner image on tag; drop broken release trigger

### DIFF
--- a/.github/workflows/herd-publish-runner.yml
+++ b/.github/workflows/herd-publish-runner.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'Dockerfile.herd_runner'
     branches: [ main ]
-  release:
-    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,46 @@ jobs:
             -t ghcr.io/herd-os/herd-runner-base:latest \
             --push .
 
+  # Rebuilds this repo's own customized runner image (Dockerfile.herd_runner)
+  # on every tag, after publish-base-image has pushed the matching base. The
+  # `--pull` flag forces buildx to fetch the just-pushed base rather than reuse
+  # a cached layer, so the wrapper always picks up base-image changes that
+  # landed in the same release (e.g. a new agent CLI baked into images/base/).
+  # Previously this lived in herd-publish-runner.yml with a `release:
+  # types: [published]` trigger, which never fired because the GitHub Release
+  # is created by GITHUB_TOKEN and GitHub blocks GITHUB_TOKEN-triggered events
+  # from cascading into other workflows.
+  publish-runner-image:
+    needs: publish-base-image
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push runner image
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          REPO=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE=ghcr.io/${OWNER}/${REPO}-herd-runner
+          docker buildx build \
+            --pull \
+            --platform linux/amd64,linux/arm64 \
+            -f Dockerfile.herd_runner \
+            -t ${IMAGE}:${VERSION} \
+            -t ${IMAGE}:latest \
+            --push .
+
   # self-init: regenerates herd-managed files (workflows, runner Dockerfile/base,
   # entrypoint, docker-compose, .env.example) on every release by running the
   # just-built `herd init --skip-labels` against this repo. If herd init produces

--- a/internal/cli/publish_runner_workflow_test.go
+++ b/internal/cli/publish_runner_workflow_test.go
@@ -37,4 +37,12 @@ func TestPublishRunnerWorkflow_Rendered(t *testing.T) {
 	// GitHub expressions must be rendered as literal ${{ ... }}, not Go template actions.
 	assert.NotContains(t, rendered, "{{`", "template escaping should be fully resolved")
 	assert.Contains(t, rendered, "${{ github.repository_owner }}")
+
+	// The `release: types: [published]` trigger was removed because GitHub
+	// silently blocks events caused by the default GITHUB_TOKEN (which
+	// creates the release) from cascading into other workflows, so the
+	// trigger never fired in practice. The workflow now runs only on
+	// workflow_dispatch and on push to Dockerfile.herd_runner.
+	assert.NotContains(t, rendered, "types: [published]", "broken release trigger should not be present")
+	assert.NotContains(t, rendered, "release:", "broken release trigger should not be present")
 }

--- a/internal/cli/workflows/herd-publish-runner.yml.tmpl
+++ b/internal/cli/workflows/herd-publish-runner.yml.tmpl
@@ -5,8 +5,6 @@ on:
     paths:
       - 'Dockerfile.herd_runner'
     branches: [ main ]
-  release:
-    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds a `publish-runner-image` job to `release.yml` that fires on every `v*` tag, after `publish-base-image`, so `ghcr.io/<owner>/<repo>-herd-runner:latest` is rebuilt against the freshly-pushed base. Uses `--pull` to bypass any cached base layer and tags both `:${VERSION}` and `:latest` for parity with the base image.
- Drops the `release: types: [published]` trigger from `herd-publish-runner.yml` (template + this repo's generated copy). It has **never fired in repo history** — GitHub silently blocks events caused by the default `GITHUB_TOKEN` (which creates the release via `softprops/action-gh-release`) from cascading into other workflows. Verified: `gh api .../actions/runs --paginate -q '.workflow_runs[] | select(.event=="release")'` returns nothing.

## Why this matters

After v0.8.9 baked `@openai/codex` into `images/base/Dockerfile`, the base image at `ghcr.io/herd-os/herd-runner-base:latest` correctly picked up codex on each tag (via `publish-base-image`, which runs off the raw tag push and isn't affected by the token cascade rule). But the wrapper image `ghcr.io/herd-os/herd-herd-runner:latest` was last rebuilt **2026-06-03 manually** — before the codex commits landed later that same day. Anyone pulling `:latest` for the past few releases has been getting a wrapper without codex, with no automated path to fix it.

The remaining triggers on `herd-publish-runner.yml` (`workflow_dispatch` + push on `Dockerfile.herd_runner`) still cover:
- consumer repos, where `herd init` bumps the base FROM tag in `Dockerfile.herd_runner` on each upgrade → push triggers rebuild
- ad-hoc manual rebuilds via the workflow_dispatch button

## Test plan

- [x] `herd init --check` clean (template + deployed copy in sync).
- [x] `TestPublishRunnerWorkflow_Rendered` updated to assert the broken `release:` trigger doesn't reappear in renders.
- [x] `go vet ./...` passes.
- [ ] On merge to `main`: cut a new tag (or wait for the next routine release) and confirm `publish-runner-image` runs in the release workflow, builds against the just-pushed base, and pushes `:<version>` + `:latest` of `ghcr.io/herd-os/herd-herd-runner`. Pulling that image on TrueNAS should give a runner with `codex` on `PATH`.