### PR TITLE
Switch agent provider to Codex (gpt-5.5) for runner dogfooding

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -4,9 +4,9 @@ platform:
     owner: Herd-OS
     repo: herd
 agent:
-    provider: claude
+    provider: codex
     binary: ""
-    model: "opus"
+    model: "gpt-5.5"
 workers:
     max_concurrent: 3
     runner_label: herd-worker


### PR DESCRIPTION
## Summary

Flips this repo's \`.herdos.yml\` from \`agent.provider: claude\` (model \`opus\`) to \`agent.provider: codex\` (model \`gpt-5.5\`) so the next dispatched batch runs through the Codex provider end-to-end on the runner side.

Validates under real worker conditions:

- The \`docker exec -it -u <RUNNER_UID> <worker> codex login --device-auth\` auth flow (PR #725) — runner-side \`codex-auth\` volume already populated.
- The \`OPENAI_API_KEY\` → \`CODEX_API_KEY\` auto-map skip when \`auth.json\` is present (PR #723).
- Headless \`herd plan\` decomposition through codex on a worker (the interactive mode from #723 only runs locally, but the headless path is exercised every time a worker picks up an issue).

## Why this is a separate PR

Keeps the config flip isolated from feature work so reverting (back to claude/opus) is a one-commit revert if Codex misbehaves on the runner.

## Test plan

- [ ] Merge this PR.
- [ ] Dispatch any batch (e.g. the next \`herd codex doctor\` plan, or any small batch). Workers should pick up jobs and run codex with \`gpt-5.5\` against the subscription \`auth.json\` mounted from the \`codex-auth\` volume.
- [ ] Confirm via worker logs that codex is the agent being invoked and that auth resolves to subscription (no quota errors, no \`OPENAI_API_KEY\` mapping).
- [ ] If Codex misbehaves on the runner, revert this PR — claude/opus comes back automatically on the next dispatch.

## Notes

- \`gpt-5.5\` is passed verbatim to \`codex --model gpt-5.5\` (no herd-side validation); the runner image has \`@openai/codex\` baked in (PR #681, unpinned in #686).
- \`agent.codex_reasoning_effort\` stays unset → defaults to \`medium\`.