### PR TITLE
Move Codex keepalive log to /opt/herd/ (runner-writable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Codex provider no longer silently overrides ChatGPT-subscription auth with `OPENAI_API_KEY`. The `OPENAI_API_KEY` -> `CODEX_API_KEY` convenience mapping is now skipped when a subscription `auth.json` exists (under `$CODEX_HOME`, or `~/.codex`), so a stray `OPENAI_API_KEY` in the shell can no longer clobber the subscription and bill against API quota. An explicit `CODEX_API_KEY` still always wins; pure API-key users (no `auth.json`) keep the mapping.
+- Codex keepalive log destination moved from `/var/log/herd-codex-keepalive.log` to `/opt/herd/herd-codex-keepalive.log`. The runner user owns `/opt/herd/` (chowned at image build time and re-chowned by the `RUNNER_UID` remap), but does not own `/var/log/` — under the unprivileged runner introduced in #712, the previous redirect failed with `Permission denied` and the keepalive process **never started**, so the OAuth chain lapsed silently after ~8 days idle on subscription-auth setups. Pure API-key and Enterprise (`CODEX_ACCESS_TOKEN`) setups were unaffected (keepalive is gated off for those).
 
 ### Removed
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -252,7 +252,7 @@ The refreshed `auth.json` in the `codex-auth` volume is the source of truth — 
 
 ##### Keepalive
 
-When `~/.codex/auth.json` is present in the `codex-auth` volume, the runner entrypoint spawns a `herd codex keepalive-loop` goroutine. It periodically triggers Codex's own refresh via a near-noop `codex exec`, keeping idle OAuth chains warm so they don't lapse between batches. The default cadence is **6 days** (a ~2-day buffer before Codex's ~8-day forced refresh) and is tunable via `HERD_CODEX_KEEPALIVE_INTERVAL`, a Go duration string (e.g. `144h`). Logs go to `/var/log/herd-codex-keepalive.log`. The keepalive is **not** spawned for API-key-only or Enterprise-only (`CODEX_ACCESS_TOKEN`) setups, which need no refresh.
+When `~/.codex/auth.json` is present in the `codex-auth` volume, the runner entrypoint spawns a `herd codex keepalive-loop` goroutine. It periodically triggers Codex's own refresh via a near-noop `codex exec`, keeping idle OAuth chains warm so they don't lapse between batches. The default cadence is **6 days** (a ~2-day buffer before Codex's ~8-day forced refresh) and is tunable via `HERD_CODEX_KEEPALIVE_INTERVAL`, a Go duration string (e.g. `144h`). Logs go to `/opt/herd/herd-codex-keepalive.log` (owned by the runner user; survives the `RUNNER_UID` remap). The keepalive is **not** spawned for API-key-only or Enterprise-only (`CODEX_ACCESS_TOKEN`) setups, which need no refresh.
 
 ##### OpenAI security warnings
 

--- a/images/base/entrypoint.herd.sh
+++ b/images/base/entrypoint.herd.sh
@@ -81,8 +81,13 @@ fi
 # only — no refresh needed) and API-key (no expiry) setups, which have no
 # auth.json.
 if [ -f /home/runner/.codex/auth.json ]; then
+  # Log to /opt/herd/ rather than /var/log/: the runner user owns /opt/herd
+  # (chowned at image build time and re-chowned by the RUNNER_UID remap
+  # earlier in this script), but does not own /var/log. A redirect into
+  # /var/log fails with "Permission denied" and the keepalive process never
+  # actually starts, so the OAuth chain lapses silently after ~8 days idle.
   /opt/herd/bin/herd codex keepalive-loop \
-    >>/var/log/herd-codex-keepalive.log 2>&1 &
+    >>/opt/herd/herd-codex-keepalive.log 2>&1 &
 fi
 
 exec ./run.sh


### PR DESCRIPTION
## Summary

The Codex keepalive entrypoint block writes to `/var/log/herd-codex-keepalive.log`, but `/var/log/` is root-owned and the entrypoint drops to the unprivileged \`runner\` user (1001 by default, or \`RUNNER_UID\` when remapped) via \`gosu\` before this line runs — see PR #712. The redirect fails with \`Permission denied\` and, because the keepalive is spawned in the background with \`&\` (which makes the failed redirect non-fatal for \`set -e\`), the process **never actually starts**. Subscription-auth users have their OAuth chain lapse silently after ~8 days idle.

Surfaced in a real-world container boot log (TrueNAS deployment):

\`\`\`
./entrypoint.herd.sh: line 84: /var/log/herd-codex-keepalive.log: Permission denied
\`\`\`

Jobs continue to run fine because the failure is non-fatal, which is exactly why this stayed hidden — the symptom is "subscription dies eight days from now," not "container crashes today."

## Fix

Redirect to \`/opt/herd/herd-codex-keepalive.log\` instead. \`/opt/herd/\` is:

- chowned to \`runner:runner\` at image build time (\`images/base/Dockerfile\`)
- included in the entrypoint's \`RUNNER_UID\` remap chown (so it survives TrueNAS-style \`RUNNER_UID=568\` setups)

One-line change in the entrypoint, plus a docs update and CHANGELOG entry.

## Scope of impact

- **Affected:** anyone running on the image since #712 with subscription auth (\`auth.json\` in the \`codex-auth\` volume). Their keepalive has never actually run; on first \`docker exec codex login\` past day ~8, the token would have lapsed and required re-login.
- **Unaffected:** API-key and Enterprise (\`CODEX_ACCESS_TOKEN\`) setups — keepalive is gated off entirely for those (\`if [ -f /home/runner/.codex/auth.json ]\` is false).

## Test plan

- [x] Shell syntax check (\`bash -n images/base/entrypoint.herd.sh\`) passes.
- [x] \`go test ./internal/cli/... -run "Keepalive|Entrypoint"\` passes (no tests reference the log path).
- [x] \`herd init --check\` clean.
- [ ] On merge → next release → runner image rebuild → restart TrueNAS container, confirm the \`Permission denied\` line is gone and that \`docker exec <c> ls -la /opt/herd/herd-codex-keepalive.log\` shows a runner-owned file.