### PR TITLE
Drop redundant codex_sandbox base now that smart defaults handle it

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -7,11 +7,6 @@ agent:
     provider: codex
     binary: ""
     model: "gpt-5.5"
-    # Explicit base override retained for zero behavior change. After the
-    # per-role sandbox defaults upgrade, this can move to
-    # agent.workers.codex_sandbox if local planning should keep Codex's
-    # workspace-write default.
-    codex_sandbox: "danger-full-access"
 workers:
     max_concurrent: 3
     runner_label: herd-worker


### PR DESCRIPTION
## Summary

PR #741 introduced execution-context-aware smart defaults for `agent.codex_sandbox`. With `provider: codex`:

- **workers role** → `danger-full-access` (regardless of `agent.exec`)
- **planner role** + `agent.exec: docker` → `danger-full-access`
- **planner role** + `agent.exec: local`/empty → `""` (Codex applies its own `workspace-write` default, which works fine on the host where bwrap can create namespaces)

The explicit base `codex_sandbox: danger-full-access` was retained in #741 to preserve byte-identical behavior at merge time, with an inline comment pointing at this follow-up. Drop it now.

## Resolved behavior

| Call site | Before this PR | After this PR |
|---|---|---|
| Worker (`herd worker exec`) | `danger-full-access` (from base) | `danger-full-access` (from smart default) — **unchanged** |
| Integrator + review | `danger-full-access` (from base, workers role) | `danger-full-access` (from smart default) — **unchanged** |
| Local `herd plan` (default `exec: ""`) | `danger-full-access` (from base) | `""` → Codex's own `workspace-write` — **changed, intentional** |
| `herd plan` with `agent.exec: docker` | `danger-full-access` (from base) | `danger-full-access` (from smart default) — **unchanged** |

The only behavior change is local `herd plan`: it now uses Codex's safer `workspace-write` sandbox on the host (where bwrap works) instead of being forced into `danger-full-access`. That's the entire point of the per-role smart-default machinery shipped in #741.

## Test plan

- [x] `herd config agent.codex_sandbox` reports `(not set)` (was `danger-full-access`).
- [x] `herd init --check` clean.
- [x] `herd config list` shows no `agent.workers.codex_sandbox` or `agent.planner.codex_sandbox` overrides — both roles rely on smart defaults.
- [ ] Next dispatched worker batch confirms codex still gets `--sandbox danger-full-access` in the worker container (visible in the codex header line as `sandbox: danger-full-access`).
- [ ] Local `herd plan` against a real prompt confirms codex starts with `sandbox: workspace-write` instead of `danger-full-access`.