### PR TITLE
Fix interactive agent process groups

### DIFF
--- a/internal/agent/claude/discuss.go
+++ b/internal/agent/claude/discuss.go
@@ -27,13 +27,16 @@ func (c *ClaudeAgent) Discuss(ctx context.Context, opts agent.DiscussOptions) er
 
 	args := buildDiscussArgs(c, opts, promptFile)
 
+	// Interactive TUIs must stay in Herd's foreground terminal process group.
+	// Do not set ProcessGroup here; headless execute/review paths opt in.
 	if err := process.Run(ctx, process.Command{
-		Path:   c.BinaryPath,
-		Args:   args,
-		Dir:    opts.RepoRoot,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Path:         c.BinaryPath,
+		Args:         args,
+		Dir:          opts.RepoRoot,
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		ProcessGroup: false,
 	}); err != nil {
 		return fmt.Errorf("claude exited with error: %w", err)
 	}

--- a/internal/agent/claude/execute.go
+++ b/internal/agent/claude/execute.go
@@ -43,12 +43,13 @@ func (c *ClaudeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts age
 	runOnce := func() (string, string, error) {
 		var stdout, stderr bytes.Buffer
 		if err := process.Run(ctx, process.Command{
-			Path:   c.BinaryPath,
-			Args:   args,
-			Dir:    opts.RepoRoot,
-			Stdin:  strings.NewReader(taskPrompt),
-			Stdout: io.MultiWriter(os.Stdout, &stdout),
-			Stderr: io.MultiWriter(os.Stderr, &stderr),
+			Path:         c.BinaryPath,
+			Args:         args,
+			Dir:          opts.RepoRoot,
+			Stdin:        strings.NewReader(taskPrompt),
+			Stdout:       io.MultiWriter(os.Stdout, &stdout),
+			Stderr:       io.MultiWriter(os.Stderr, &stderr),
+			ProcessGroup: true,
 		}); err != nil {
 			return "", stderr.String(), fmt.Errorf("agent exited with error: %w\n%s", err, stderr.String())
 		}

--- a/internal/agent/claude/plan.go
+++ b/internal/agent/claude/plan.go
@@ -26,13 +26,16 @@ func (c *ClaudeAgent) Plan(ctx context.Context, initialPrompt string, opts agent
 
 	args := buildPlanArgs(c, initialPrompt, promptFile)
 
+	// Interactive TUIs must stay in Herd's foreground terminal process group.
+	// Do not set ProcessGroup here; headless execute/review paths opt in.
 	if err := process.Run(ctx, process.Command{
-		Path:   c.BinaryPath,
-		Args:   args,
-		Dir:    opts.RepoRoot,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Path:         c.BinaryPath,
+		Args:         args,
+		Dir:          opts.RepoRoot,
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		ProcessGroup: false,
 	}); err != nil {
 		return nil, fmt.Errorf("claude exited with error: %w", err)
 	}

--- a/internal/agent/claude/plan_test.go
+++ b/internal/agent/claude/plan_test.go
@@ -141,6 +141,10 @@ func TestReview_UnixContextCancellationTerminatesDescendants(t *testing.T) {
 		t.Skip("process group termination is Unix-only")
 	}
 
+	// Interactive plan/discuss sessions intentionally do not opt into process
+	// groups because TUIs must remain in the terminal foreground process group;
+	// internal/agent/process covers that default behavior directly. Headless
+	// review/execute paths retain descendant cleanup.
 	tests := []struct {
 		name string
 		run  func(context.Context, *ClaudeAgent, string) error

--- a/internal/agent/claude/plan_test.go
+++ b/internal/agent/claude/plan_test.go
@@ -136,7 +136,7 @@ func TestPlan_PassesInitialPromptAsPositional(t *testing.T) {
 	}
 }
 
-func TestInteractivePaths_UnixContextCancellationTerminatesDescendants(t *testing.T) {
+func TestReview_UnixContextCancellationTerminatesDescendants(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process group termination is Unix-only")
 	}
@@ -145,26 +145,6 @@ func TestInteractivePaths_UnixContextCancellationTerminatesDescendants(t *testin
 		name string
 		run  func(context.Context, *ClaudeAgent, string) error
 	}{
-		{
-			name: "plan",
-			run: func(ctx context.Context, c *ClaudeAgent, repoRoot string) error {
-				_, err := c.Plan(ctx, "plan work", agent.PlanOptions{
-					RepoRoot:   repoRoot,
-					OutputPath: filepath.Join(repoRoot, "plan.json"),
-					Context:    map[string]string{},
-				})
-				return err
-			},
-		},
-		{
-			name: "discuss",
-			run: func(ctx context.Context, c *ClaudeAgent, repoRoot string) error {
-				return c.Discuss(ctx, agent.DiscussOptions{
-					RepoRoot:     repoRoot,
-					SystemPrompt: "discuss work",
-				})
-			},
-		},
 		{
 			name: "review",
 			run: func(ctx context.Context, c *ClaudeAgent, repoRoot string) error {

--- a/internal/agent/claude/review.go
+++ b/internal/agent/claude/review.go
@@ -39,12 +39,13 @@ func (c *ClaudeAgent) Review(ctx context.Context, diff string, opts agent.Review
 	runOnce := func() (string, string, error) {
 		var stdout, stderr bytes.Buffer
 		if err := process.Run(ctx, process.Command{
-			Path:   c.BinaryPath,
-			Args:   args,
-			Dir:    opts.RepoRoot,
-			Stdin:  strings.NewReader(reviewPrompt),
-			Stdout: io.MultiWriter(os.Stdout, &stdout),
-			Stderr: io.MultiWriter(os.Stderr, &stderr),
+			Path:         c.BinaryPath,
+			Args:         args,
+			Dir:          opts.RepoRoot,
+			Stdin:        strings.NewReader(reviewPrompt),
+			Stdout:       io.MultiWriter(os.Stdout, &stdout),
+			Stderr:       io.MultiWriter(os.Stderr, &stderr),
+			ProcessGroup: true,
 		}); err != nil {
 			return "", stderr.String(), fmt.Errorf("agent review exited with error: %w\n%s", err, stderr.String())
 		}

--- a/internal/agent/codex/execute.go
+++ b/internal/agent/codex/execute.go
@@ -47,12 +47,13 @@ func (c *CodexAgent) Execute(ctx context.Context, task agent.TaskSpec, opts agen
 	runOnce := func() (finalMsg, stdout, stderr string, err error) {
 		var outBuf, errBuf bytes.Buffer
 		runErr := agentprocess.Run(ctx, agentprocess.Command{
-			Path:   c.BinaryPath,
-			Args:   args,
-			Dir:    opts.RepoRoot,
-			Env:    childEnv(),
-			Stdout: io.MultiWriter(os.Stdout, &outBuf),
-			Stderr: io.MultiWriter(os.Stderr, &errBuf),
+			Path:         c.BinaryPath,
+			Args:         args,
+			Dir:          opts.RepoRoot,
+			Env:          childEnv(),
+			Stdout:       io.MultiWriter(os.Stdout, &outBuf),
+			Stderr:       io.MultiWriter(os.Stderr, &errBuf),
+			ProcessGroup: true,
 		})
 		if runErr != nil {
 			return "", "", errBuf.String(), fmt.Errorf("agent exited with error: %w\n%s", runErr, errBuf.String())

--- a/internal/agent/codex/plan.go
+++ b/internal/agent/codex/plan.go
@@ -119,14 +119,17 @@ func (c *CodexAgent) planInteractive(ctx context.Context, systemPrompt string, o
 		"HERD_PLAN_SCHEMA="+schemaFile,
 	)
 	// Interactive mode: wire stdio through to the user's TTY.
+	// Keep the TUI in Herd's foreground terminal process group. Do not set
+	// ProcessGroup here; headless exec/review paths opt in.
 	if err := agentprocess.Run(ctx, agentprocess.Command{
-		Path:   c.BinaryPath,
-		Args:   args,
-		Dir:    opts.RepoRoot,
-		Env:    env,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Path:         c.BinaryPath,
+		Args:         args,
+		Dir:          opts.RepoRoot,
+		Env:          env,
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		ProcessGroup: false,
 	}); err != nil {
 		return nil, fmt.Errorf("codex exited with error: %w", err)
 	}

--- a/internal/agent/codex/plan.go
+++ b/internal/agent/codex/plan.go
@@ -65,12 +65,13 @@ func (c *CodexAgent) planHeadless(ctx context.Context, systemPrompt, initialProm
 	// Headless mode: stdin is not a TTY. The structured plan is read from the
 	// output file, so just stream child stdout/stderr to the parent.
 	if err := agentprocess.Run(ctx, agentprocess.Command{
-		Path:   c.BinaryPath,
-		Args:   args,
-		Dir:    opts.RepoRoot,
-		Env:    childEnv(),
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Path:         c.BinaryPath,
+		Args:         args,
+		Dir:          opts.RepoRoot,
+		Env:          childEnv(),
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		ProcessGroup: true,
 	}); err != nil {
 		return nil, fmt.Errorf("codex exited with error: %w", err)
 	}

--- a/internal/agent/codex/review.go
+++ b/internal/agent/codex/review.go
@@ -53,12 +53,13 @@ func (c *CodexAgent) Review(ctx context.Context, diff string, opts agent.ReviewO
 	runOnce := func() (finalMsg, stdout, stderr string, err error) {
 		var outBuf, errBuf bytes.Buffer
 		runErr := agentprocess.Run(ctx, agentprocess.Command{
-			Path:   c.BinaryPath,
-			Args:   args,
-			Dir:    opts.RepoRoot,
-			Env:    childEnv(),
-			Stdout: io.MultiWriter(os.Stdout, &outBuf),
-			Stderr: io.MultiWriter(os.Stderr, &errBuf),
+			Path:         c.BinaryPath,
+			Args:         args,
+			Dir:          opts.RepoRoot,
+			Env:          childEnv(),
+			Stdout:       io.MultiWriter(os.Stdout, &outBuf),
+			Stderr:       io.MultiWriter(os.Stderr, &errBuf),
+			ProcessGroup: true,
 		})
 		if runErr != nil {
 			return "", "", errBuf.String(), fmt.Errorf("agent review exited with error: %w\n%s", runErr, errBuf.String())

--- a/internal/agent/opencode/discuss.go
+++ b/internal/agent/opencode/discuss.go
@@ -36,13 +36,16 @@ func (o *OpenCodeAgent) Discuss(ctx context.Context, opts agent.DiscussOptions) 
 
 	args := buildInteractiveArgs(o.Model, combined)
 
+	// Interactive TUIs must stay in Herd's foreground terminal process group.
+	// Do not set ProcessGroup here; headless execute/review paths opt in.
 	if err := process.Run(ctx, process.Command{
-		Path:   o.BinaryPath,
-		Args:   args,
-		Dir:    opts.RepoRoot,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Path:         o.BinaryPath,
+		Args:         args,
+		Dir:          opts.RepoRoot,
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		ProcessGroup: false,
 	}); err != nil {
 		return fmt.Errorf("opencode exited with error: %w", err)
 	}

--- a/internal/agent/opencode/execute.go
+++ b/internal/agent/opencode/execute.go
@@ -38,12 +38,13 @@ func (o *OpenCodeAgent) Execute(ctx context.Context, task agent.TaskSpec, opts a
 		// large prompts. OpenCode `run` reads stdin when it is not a TTY.
 		var stdout, stderr bytes.Buffer
 		if err := process.Run(ctx, process.Command{
-			Path:   o.BinaryPath,
-			Args:   args,
-			Dir:    opts.RepoRoot,
-			Stdin:  strings.NewReader(taskPrompt),
-			Stdout: io.MultiWriter(os.Stdout, &stdout),
-			Stderr: io.MultiWriter(os.Stderr, &stderr),
+			Path:         o.BinaryPath,
+			Args:         args,
+			Dir:          opts.RepoRoot,
+			Stdin:        strings.NewReader(taskPrompt),
+			Stdout:       io.MultiWriter(os.Stdout, &stdout),
+			Stderr:       io.MultiWriter(os.Stderr, &stderr),
+			ProcessGroup: true,
 		}); err != nil {
 			return "", stderr.String(), fmt.Errorf("agent exited with error: %w\n%s", err, stderr.String())
 		}

--- a/internal/agent/opencode/plan.go
+++ b/internal/agent/opencode/plan.go
@@ -37,13 +37,16 @@ func (o *OpenCodeAgent) Plan(ctx context.Context, initialPrompt string, opts age
 
 	args := buildInteractiveArgs(o.Model, combined)
 
+	// Interactive TUIs must stay in Herd's foreground terminal process group.
+	// Do not set ProcessGroup here; headless execute/review paths opt in.
 	if err := process.Run(ctx, process.Command{
-		Path:   o.BinaryPath,
-		Args:   args,
-		Dir:    opts.RepoRoot,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Path:         o.BinaryPath,
+		Args:         args,
+		Dir:          opts.RepoRoot,
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		Stderr:       os.Stderr,
+		ProcessGroup: false,
 	}); err != nil {
 		return nil, fmt.Errorf("opencode exited with error: %w", err)
 	}

--- a/internal/agent/opencode/plan_test.go
+++ b/internal/agent/opencode/plan_test.go
@@ -264,7 +264,7 @@ func TestDiscuss_FoldsSystemAndInitialIntoPrompt(t *testing.T) {
 	}
 }
 
-func TestInteractivePaths_UnixContextCancellationTerminatesDescendants(t *testing.T) {
+func TestReview_UnixContextCancellationTerminatesDescendants(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process group termination is Unix-only")
 	}
@@ -273,26 +273,6 @@ func TestInteractivePaths_UnixContextCancellationTerminatesDescendants(t *testin
 		name string
 		run  func(context.Context, *OpenCodeAgent, string) error
 	}{
-		{
-			name: "plan",
-			run: func(ctx context.Context, o *OpenCodeAgent, repoRoot string) error {
-				_, err := o.Plan(ctx, "plan work", agent.PlanOptions{
-					RepoRoot:   repoRoot,
-					OutputPath: filepath.Join(repoRoot, "plan.json"),
-					Context:    map[string]string{},
-				})
-				return err
-			},
-		},
-		{
-			name: "discuss",
-			run: func(ctx context.Context, o *OpenCodeAgent, repoRoot string) error {
-				return o.Discuss(ctx, agent.DiscussOptions{
-					RepoRoot:     repoRoot,
-					SystemPrompt: "discuss work",
-				})
-			},
-		},
 		{
 			name: "review",
 			run: func(ctx context.Context, o *OpenCodeAgent, repoRoot string) error {

--- a/internal/agent/opencode/plan_test.go
+++ b/internal/agent/opencode/plan_test.go
@@ -269,6 +269,10 @@ func TestReview_UnixContextCancellationTerminatesDescendants(t *testing.T) {
 		t.Skip("process group termination is Unix-only")
 	}
 
+	// Interactive plan/discuss sessions intentionally do not opt into process
+	// groups because TUIs must remain in the terminal foreground process group;
+	// internal/agent/process covers that default behavior directly. Headless
+	// review/execute paths retain descendant cleanup.
 	tests := []struct {
 		name string
 		run  func(context.Context, *OpenCodeAgent, string) error

--- a/internal/agent/opencode/review.go
+++ b/internal/agent/opencode/review.go
@@ -37,12 +37,13 @@ func (o *OpenCodeAgent) Review(ctx context.Context, diff string, opts agent.Revi
 		// a TTY.
 		var stdout, stderr bytes.Buffer
 		if err := process.Run(ctx, process.Command{
-			Path:   o.BinaryPath,
-			Args:   args,
-			Dir:    opts.RepoRoot,
-			Stdin:  strings.NewReader(message),
-			Stdout: io.MultiWriter(os.Stdout, &stdout),
-			Stderr: io.MultiWriter(os.Stderr, &stderr),
+			Path:         o.BinaryPath,
+			Args:         args,
+			Dir:          opts.RepoRoot,
+			Stdin:        strings.NewReader(message),
+			Stdout:       io.MultiWriter(os.Stdout, &stdout),
+			Stderr:       io.MultiWriter(os.Stderr, &stderr),
+			ProcessGroup: true,
 		}); err != nil {
 			return "", stderr.String(), fmt.Errorf("agent review exited with error: %w\n%s", err, stderr.String())
 		}

--- a/internal/agent/process/process.go
+++ b/internal/agent/process/process.go
@@ -10,13 +10,18 @@ import (
 const defaultGracePeriod = 2 * time.Second
 
 type Command struct {
-	Path         string
-	Args         []string
-	Dir          string
-	Env          []string
-	Stdin        io.Reader
-	Stdout       io.Writer
-	Stderr       io.Writer
+	Path   string
+	Args   []string
+	Dir    string
+	Env    []string
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+	// ProcessGroup starts the child in a private process group so context
+	// cancellation can terminate descendants. Use it for headless commands.
+	// Do not use it for interactive TUIs attached to the user's terminal:
+	// moving the child out of the terminal foreground process group can stop
+	// or hang the TUI when it reads from stdin.
 	ProcessGroup bool
 }
 

--- a/internal/agent/process/process.go
+++ b/internal/agent/process/process.go
@@ -10,13 +10,14 @@ import (
 const defaultGracePeriod = 2 * time.Second
 
 type Command struct {
-	Path   string
-	Args   []string
-	Dir    string
-	Env    []string
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
+	Path         string
+	Args         []string
+	Dir          string
+	Env          []string
+	Stdin        io.Reader
+	Stdout       io.Writer
+	Stderr       io.Writer
+	ProcessGroup bool
 }
 
 func Run(ctx context.Context, spec Command) error {
@@ -30,7 +31,7 @@ func Run(ctx context.Context, spec Command) error {
 	cmd.Stdin = spec.Stdin
 	cmd.Stdout = spec.Stdout
 	cmd.Stderr = spec.Stderr
-	configureCommand(cmd)
+	configureCommand(cmd, spec.ProcessGroup)
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -45,7 +46,7 @@ func Run(ctx context.Context, spec Command) error {
 	case err := <-waitCh:
 		return err
 	case <-ctx.Done():
-		terminateCommand(cmd, waitCh)
+		terminateCommand(cmd, waitCh, spec.ProcessGroup)
 		return ctx.Err()
 	}
 }

--- a/internal/agent/process/process_test.go
+++ b/internal/agent/process/process_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -82,6 +83,25 @@ func TestRun_PreCancelledContextDoesNotLaunch(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "pre-cancelled Run must not launch the child")
 }
 
+func TestRun_DefaultDoesNotCreateNewProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group test is Unix-only")
+	}
+
+	script := writeShellScript(t, "pgid.sh", "ps -o pgid= -p $$\n")
+
+	var stdout bytes.Buffer
+	err := Run(context.Background(), Command{
+		Path:   script,
+		Stdout: &stdout,
+	})
+
+	require.NoError(t, err)
+	got, err := strconv.Atoi(strings.TrimSpace(stdout.String()))
+	require.NoError(t, err)
+	assert.Equal(t, syscall.Getpgrp(), got)
+}
+
 func TestRun_UnixContextCancellationTerminatesDescendants(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process group termination is Unix-only")
@@ -101,7 +121,7 @@ wait "$child"
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := Run(ctx, Command{Path: script})
+	err := Run(ctx, Command{Path: script, ProcessGroup: true})
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	pid := readPIDFile(t, pidFile)
@@ -130,7 +150,7 @@ wait "$!"
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- Run(ctx, Command{Path: script})
+		errCh <- Run(ctx, Command{Path: script, ProcessGroup: true})
 	}()
 
 	require.Eventually(t, func() bool {

--- a/internal/agent/process/process_unix.go
+++ b/internal/agent/process/process_unix.go
@@ -9,12 +9,20 @@ import (
 	"time"
 )
 
-func configureCommand(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+func configureCommand(cmd *exec.Cmd, processGroup bool) {
+	if processGroup {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 }
 
-func terminateCommand(cmd *exec.Cmd, waitCh <-chan error) {
+func terminateCommand(cmd *exec.Cmd, waitCh <-chan error, processGroup bool) {
 	if cmd.Process == nil {
+		return
+	}
+
+	if !processGroup {
+		_ = cmd.Process.Kill()
+		<-waitCh
 		return
 	}
 

--- a/internal/agent/process/process_windows.go
+++ b/internal/agent/process/process_windows.go
@@ -4,9 +4,9 @@ package process
 
 import "os/exec"
 
-func configureCommand(cmd *exec.Cmd) {}
+func configureCommand(cmd *exec.Cmd, _ bool) {}
 
-func terminateCommand(cmd *exec.Cmd, waitCh <-chan error) {
+func terminateCommand(cmd *exec.Cmd, waitCh <-chan error, _ bool) {
 	if cmd.Process != nil {
 		_ = cmd.Process.Kill()
 	}


### PR DESCRIPTION
## Summary

- Make process-group isolation opt-in for agent subprocesses
- Keep interactive plan/discuss sessions in the terminal foreground process group
- Preserve process-tree cleanup for headless execute/review/headless-plan paths

## Testing

- ok  	github.com/herd-os/herd/internal/agent/process	2.200s
ok  	github.com/herd-os/herd/internal/agent/codex	5.307s
ok  	github.com/herd-os/herd/internal/agent/claude	30.558s
ok  	github.com/herd-os/herd/internal/agent/opencode	30.562s
- ok  	github.com/herd-os/herd/internal/cli	20.689s
- Built Herd turns GitHub into your orchestration layer for AI coding agents.
Work is tracked as Issues, executed by Actions on self-hosted runners,
and landed as a single reviewed PR.

Usage:
  herd [flags]
  herd [command]

Available Commands:
  batch       Manage batches
  codex       Codex provider tools
  completion  Generate the autocompletion script for the specified shell
  config      View/edit configuration
  dashboard   Live TUI dashboard for open batches
  dispatch    Dispatch workers to execute issues
  help        Help about any command
  image       Build and publish the customized runner image
  init        Set up a repo for HerdOS
  plan        Plan and decompose work into issues
  review      Open an interactive agent session scoped to a PR
  runner      Manage runners
  status      Show system status

Flags:
  -h, --help       help for herd
      --help-all   Show all commands including internal ones
  -v, --version    version for herd

Use "herd [command] --help" for more information about a command. and manually verified ⟳ Fetching from origin...✓ Fetched from origin    
⚠ You're on branch 'fix/interactive-agent-process-group'. Switch to 'main' and pull latest? [Y/n] ⚠ Working tree has uncommitted changes. The planner will see your local state. no longer freezes locally