### PR TITLE
Disable strip/debug processing for AUR binary package

### DIFF
--- a/scripts/update-aur.sh
+++ b/scripts/update-aur.sh
@@ -84,6 +84,7 @@ optdepends=('docker: self-hosted worker runner containers'
             'docker-compose: legacy docker-compose-based runner deployment')
 provides=('herd')
 conflicts=('herd' 'herd-git')
+options=('!strip' '!debug')
 source_x86_64=("herd-\$pkgver-x86_64::https://github.com/Herd-OS/herd/releases/download/v\$pkgver/herd-linux-amd64")
 source_aarch64=("herd-\$pkgver-aarch64::https://github.com/Herd-OS/herd/releases/download/v\$pkgver/herd-linux-arm64")
 sha256sums_x86_64=('${SHA_LINUX_AMD64}')


### PR DESCRIPTION
## Summary

- Add `options=('!strip' '!debug')` to the generated `herd-bin` PKGBUILD.
- Prevent Arch `makepkg` from running strip/debugedit on the downloaded Go release binary.
- This removes the noisy `debugedit: ./usr/bin/herd: Unsupported .debug_line directory 0 path DW_FORM_0x8` messages during AUR installs.

## Test

- `bash -n scripts/update-aur.sh`
- Generated a throwaway PKGBUILD for v0.8.27 in `/tmp/herd-aur-test`.
- `makepkg -f` completed without `debugedit` warnings.
- `makepkg --printsrcinfo` includes `options = !strip` and `options = !debug`.
