### PR TITLE
Align worker validation instructions with CI

### DIFF
--- a/.herd/worker.md
+++ b/.herd/worker.md
@@ -3,7 +3,8 @@
 - Use testify/assert and testify/require, not raw if/t.Fatal.
 - Before pushing, you MUST run ALL of the following and fix any failures:
   1. go build ./...
-  2. go test ./...
+  2. go test ./... -count=1 -race
   3. go vet ./...
   4. golangci-lint run
+- Do NOT substitute weaker validation commands. Plain `go test ./...` is not sufficient for this repository because CI runs the race detector.
 - Do NOT push code that fails any of these checks. Fix the issues first.


### PR DESCRIPTION
## Summary

Update Herd's worker instructions so required pre-push validation matches CI.

## Changes

- Replace plain `go test ./...` with `go test ./... -count=1 -race`.
- Add an explicit warning not to substitute weaker validation commands.

## Validation

Not run; documentation/instruction-only change.
