### PR TITLE
Raise Herd review chunk limit on main

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -17,6 +17,8 @@ integrator:
     max_conflict_resolution_attempts: 2
     require_ci: true
     review: true
+    review_diff:
+        max_chunks: 10
     review_max_fix_cycles: 0
     review_fix_severity: low
     ci_max_fix_cycles: 0


### PR DESCRIPTION
## Summary

- Set this repository Herd review diff chunk limit to 10 in .herdos.yml.
- Keeps large Herd PR reviews from falling back to the default 8 chunk limit when commands or config are sourced from main.

## Context

PR #849 already had integrator.review_diff.max_chunks set to 10 on its branch, but the latest review ran with max chunks: 8. That matches main default config. Landing this config on main makes future manual review runs use the intended 10 chunk budget.

## Validation

- GOCACHE=/tmp/herd-go-cache go test ./internal/config -count=1
