### PR TITLE
Increase Herd review chunk budget

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -18,7 +18,7 @@ integrator:
     require_ci: true
     review: true
     review_diff:
-        max_chunks: 10
+        max_chunks: 20
     review_max_fix_cycles: 0
     review_fix_severity: low
     ci_max_fix_cycles: 0


### PR DESCRIPTION
## Summary

- Increase this repository's Herd review diff chunk budget from 10 to 20.
- This allows very large PRs, including the hosted GitHub App PR, to receive complete review coverage during the current experiment.

## Testing

- Not run; configuration-only change.