### PR TITLE
Use GPT-5.6 Sol for Herd jobs

### DIFF
--- a/.herdos.yml
+++ b/.herdos.yml
@@ -6,7 +6,8 @@ platform:
 agent:
     provider: codex
     binary: ""
-    model: "gpt-5.5"
+    model: "gpt-5.6-sol"
+    codex_reasoning_effort: "medium"
 workers:
     max_concurrent: 3
     runner_label: herd-worker


### PR DESCRIPTION
## Summary

- update Herd's Codex model from `gpt-5.5` to `gpt-5.6-sol`
- explicitly keep Codex reasoning effort at `medium`
- bring the model configuration being tested on PR #849 to `main`

## Verification

- `GOCACHE=/tmp/herd-go-build-cache go test ./internal/config`